### PR TITLE
feat(companion): path_hash_mode as a per-companion config setting

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -406,6 +406,8 @@ identities:
     #     tcp_port: 5000
     #     bind_address: "0.0.0.0"
     #     tcp_timeout: 120   # seconds; default 120 when omitted; 0 = disable (no timeout)
+    #     path_hash_mode: 1  # origin path hash width: 0=1-byte (default), 1=2-byte,
+    #                        # 2=3-byte; config wins over the client-set pref at startup
     # - name: "BotCompanion"
     #   identity_key: "another_companion_identity_key_hex"
     #   settings:

--- a/repeater/companion/bridge.py
+++ b/repeater/companion/bridge.py
@@ -75,6 +75,7 @@ class RepeaterCompanionBridge(CompanionBridge):
         sqlite_handler=None,
         companion_hash: str = "",
         on_prefs_saved: Optional[Callable[[str], None]] = None,
+        path_hash_mode: "int | None" = None,
     ) -> None:
         self._sqlite_handler = sqlite_handler
         self._companion_hash = companion_hash
@@ -93,6 +94,13 @@ class RepeaterCompanionBridge(CompanionBridge):
             radio_settings_getter=radio_settings_getter,
             max_tx_power_getter=max_tx_power_getter,
         )
+        # Config-provided width wins over the persisted pref at startup
+        # (CompanionBase.__init__ above has already run _load_prefs). Not
+        # persisted here on purpose: removing the key from the config hands
+        # control back to the client-set pref instead of freezing the last
+        # configured value.
+        if path_hash_mode is not None:
+            self.prefs.path_hash_mode = path_hash_mode
 
     def _save_prefs(self) -> None:
         """Persist full NodePrefs as JSON to SQLite."""

--- a/repeater/companion/utils.py
+++ b/repeater/companion/utils.py
@@ -106,6 +106,23 @@ def parse_companion_bridge_kwargs(settings: dict) -> Dict[str, int]:
         kwargs["offline_queue_size"] = parse_positive_int(
             settings["offline_queue_size"], "offline_queue_size", minimum=0
         )
+    if "path_hash_mode" in settings:
+        # Origin path hash width for this companion identity: 0=1-byte,
+        # 1=2-byte, 2=3-byte. Applied after the persisted prefs load, so the
+        # config value wins at startup; clients can still change it at
+        # runtime over the companion protocol. Invalid values are ignored
+        # with a warning rather than failing the daemon start.
+        try:
+            mode = int(settings["path_hash_mode"])
+        except (TypeError, ValueError):
+            mode = -1
+        if mode in (0, 1, 2):
+            kwargs["path_hash_mode"] = mode
+        else:
+            logger.warning(
+                "Companion setting path_hash_mode=%r is invalid (must be 0, 1 or 2); ignoring",
+                settings["path_hash_mode"],
+            )
     return kwargs
 
 

--- a/tests/test_companion_bridge_prefs.py
+++ b/tests/test_companion_bridge_prefs.py
@@ -84,3 +84,58 @@ def test_bridge_accepts_host_radio_callbacks(identity):
         "airtime_factor": 1.0,
     }
     assert bridge.get_max_tx_power_dbm() == 20
+
+
+def test_config_path_hash_mode_wins_over_persisted(identity):
+    """settings.path_hash_mode must override the persisted pref at startup."""
+
+    class FakeSqlite:
+        def companion_load_prefs(self, companion_hash: str):
+            return {"path_hash_mode": 0}
+
+        def companion_save_prefs(self, companion_hash: str, prefs: dict) -> bool:
+            return True
+
+    async def inject(pkt, wait_for_ack=False):
+        return True
+
+    bridge = RepeaterCompanionBridge(
+        identity,
+        inject,
+        sqlite_handler=FakeSqlite(),
+        companion_hash="testhash",
+        path_hash_mode=1,
+    )
+    assert bridge.prefs.path_hash_mode == 1
+
+
+def test_persisted_path_hash_mode_survives_without_config_key(identity):
+    """Without the config key, the client-set persisted pref stays in charge."""
+
+    class FakeSqlite:
+        def companion_load_prefs(self, companion_hash: str):
+            return {"path_hash_mode": 2}
+
+        def companion_save_prefs(self, companion_hash: str, prefs: dict) -> bool:
+            return True
+
+    async def inject(pkt, wait_for_ack=False):
+        return True
+
+    bridge = RepeaterCompanionBridge(
+        identity,
+        inject,
+        sqlite_handler=FakeSqlite(),
+        companion_hash="testhash",
+    )
+    assert bridge.prefs.path_hash_mode == 2
+
+
+def test_parse_companion_bridge_kwargs_path_hash_mode():
+    """Parser accepts 0/1/2 and ignores invalid values instead of raising."""
+    from repeater.companion.utils import parse_companion_bridge_kwargs
+
+    assert parse_companion_bridge_kwargs({"path_hash_mode": 1}) == {"path_hash_mode": 1}
+    assert parse_companion_bridge_kwargs({"path_hash_mode": "2"}) == {"path_hash_mode": 2}
+    assert parse_companion_bridge_kwargs({"path_hash_mode": 5}) == {}
+    assert parse_companion_bridge_kwargs({"path_hash_mode": "junk"}) == {}


### PR DESCRIPTION
## Summary

Implements the config side of #257 (confirmed there as "on the todo list"): a per-companion `settings.path_hash_mode` (0=1-byte, 1=2-byte, 2=3-byte) that seeds the companion's origin path-hash width at startup.

Until now the width could only be set by a connected client over the companion protocol, so fleets standardizing on 2-byte hashes had to teach every client (bots, exporters, ad-hoc scripts) to call `set_path_hash_mode` on connect — and any client that forgot transmitted 1-byte origins.

## Behavior

- Applied **after** the persisted-prefs load, so the config value wins on boot.
- Clients can still change the width at runtime over the companion protocol.
- Deliberately **not persisted** by the seeding itself: removing the key from the config hands control back to the client-set pref instead of freezing the last configured value.
- Invalid values are ignored with a warning instead of failing daemon start (matching `mesh.path_hash_mode` handling).
- Plumbed through `parse_companion_bridge_kwargs`, so both the startup loop and `add_companion_from_config` (hot-reload) honor it.
- `config.yaml.example` documents the key.

## Tests

- `test_config_path_hash_mode_wins_over_persisted`
- `test_persisted_path_hash_mode_survives_without_config_key`
- `test_parse_companion_bridge_kwargs_path_hash_mode` (accepts 0/1/2, ignores junk)
- `python -m pytest -q tests/test_companion_bridge_prefs.py` — 6 passed
- `ruff check` / `ruff format --check` on touched files: no new findings vs `dev`

We run this in production on two nodes (bots + Prometheus exporter sharing companion identities) on the Czech community mesh.