### PR TITLE
feat(fabric): plumb fabric.origin_tx (default|all) to the core RFFabric

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -428,6 +428,11 @@ identities:
 #     # sticky:  TX on the radio that last received (same-band reply)
 #     # bridge:  TX on the *other* radio (dual-freq LoRa backhaul)
 #     #          RX local -> TX link, RX link -> TX local
+#   origin_tx: default            # default | all
+#     # default: locally originated packets TX default_radio only
+#     # all:     fan origins out to every radio, sequentially in config
+#     #          order (bridge topologies: tx_mode steers forwards, but an
+#     #          origin has no RX side and would never cross the link)
 #
 # Dual CH341 USB adapters example (different USB bus/address per radio):
 # radios:

--- a/repeater/config.py
+++ b/repeater/config.py
@@ -834,6 +834,31 @@ def _apply_fabric_tx_mode(fabric, mode: str) -> None:
     raise ValueError(f"Unknown fabric.tx_mode={mode!r}. Supported: default, sticky, bridge")
 
 
+def _apply_fabric_origin_tx(fabric, mode: str) -> None:
+    """Forward fabric.origin_tx onto the core RFFabric.
+
+    Modes:
+    - default: locally originated packets TX ``default_radio`` (current
+               behaviour).
+    - all:     fan origins out to every registered radio, sequentially in
+               registration order. Bridge topologies need this: tx_mode
+               only steers *forwards* (RX radio -> the other radio); an
+               origin packet has no RX side, so without fan-out it leaves
+               on a single radio and never crosses the link.
+    """
+    mode_l = (mode or "default").strip().lower()
+    if mode_l in ("", "default"):
+        return
+    if mode_l != "all":
+        raise ValueError(f"Unknown fabric.origin_tx={mode!r}. Supported: default, all")
+    if not hasattr(fabric, "set_origin_tx"):
+        raise RuntimeError(
+            "fabric.origin_tx requires openhop-core with origin fan-out support; "
+            "upgrade openhop-core."
+        )
+    fabric.set_origin_tx(mode_l)
+
+
 def build_radio_stack(config: dict):
     """Build single- or multi-radio stack for the repeater.
 
@@ -847,6 +872,7 @@ def build_radio_stack(config: dict):
     fabric_cfg = config.get("fabric") if isinstance(config.get("fabric"), dict) else {}
     use_fabric = bool(fabric_cfg.get("use_fabric", False))
     tx_mode = str(fabric_cfg.get("tx_mode", "default"))
+    origin_tx = str(fabric_cfg.get("origin_tx", "default"))
     default_radio = fabric_cfg.get("default_radio") or fabric_cfg.get("default_radio_id")
 
     meta = {
@@ -854,6 +880,7 @@ def build_radio_stack(config: dict):
         "radio_ids": [],
         "default_radio": None,
         "tx_mode": tx_mode,
+        "origin_tx": origin_tx,
         "fabric": False,
     }
 
@@ -876,6 +903,7 @@ def build_radio_stack(config: dict):
         default_id = str(default_radio) if default_radio else pairs[0][1]
         radio = FabricRadio(radios=pairs, default_radio_id=default_id)
         _apply_fabric_tx_mode(radio.fabric, tx_mode)
+        _apply_fabric_origin_tx(radio.fabric, origin_tx)
 
         meta.update(
             {
@@ -901,6 +929,7 @@ def build_radio_stack(config: dict):
         rid = str(default_radio or "radio0")
         radio = FabricRadio(radio=physical, radio_id=rid, default_radio_id=rid)
         _apply_fabric_tx_mode(radio.fabric, tx_mode)
+        _apply_fabric_origin_tx(radio.fabric, origin_tx)
         meta.update(
             {
                 "mode": "single_fabric",

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -329,11 +329,12 @@ class RepeaterDaemon:
                 meta = getattr(self, "radio_stack_meta", {}) or {}
                 if meta.get("fabric"):
                     logger.info(
-                        "RF fabric active: mode=%s radios=%s default=%s tx_mode=%s",
+                        "RF fabric active: mode=%s radios=%s default=%s tx_mode=%s origin_tx=%s",
                         meta.get("mode"),
                         meta.get("radio_ids"),
                         meta.get("default_radio"),
                         meta.get("tx_mode"),
+                        meta.get("origin_tx"),
                     )
 
                 # Physical radios for per-device setup (CAD, event loop).

--- a/tests/test_multi_radio_stack.py
+++ b/tests/test_multi_radio_stack.py
@@ -12,6 +12,13 @@ from repeater.config import (
     build_radio_stack,
 )
 
+try:
+    from openhop_core.rf_fabric import RFFabric
+
+    _CORE_HAS_ORIGIN_TX = hasattr(RFFabric, "set_origin_tx")
+except ImportError:  # pragma: no cover - core is a hard dependency
+    _CORE_HAS_ORIGIN_TX = False
+
 
 class _FakeRadio:
     def __init__(self, name="r"):
@@ -230,3 +237,73 @@ def test_merge_radio_entry_preserves_per_radio_ch341():
     merged = _merge_radio_entry(global_cfg, entry)
     assert merged["ch341"]["address"] == 8
     assert merged["_ch341_per_instance"] is True
+
+
+def _two_radio_cfg(fabric_cfg):
+    return {
+        "fabric": fabric_cfg,
+        "radios": [
+            {
+                "id": "local",
+                "radio_type": "sx1262",
+                "radio": {"frequency": 111},
+                "sx1262": {"bus_id": 0},
+            },
+            {
+                "id": "link",
+                "radio_type": "sx1262",
+                "radio": {"frequency": 222},
+                "sx1262": {"bus_id": 0},
+            },
+        ],
+    }
+
+
+@pytest.mark.skipif(
+    not _CORE_HAS_ORIGIN_TX,
+    reason="needs openhop-core with fabric origin_tx support",
+)
+def test_origin_tx_all_applied_to_fabric():
+    a = _FakeRadio("a")
+    b = _FakeRadio("b")
+
+    def fake_get(board):
+        freq = (board.get("radio") or {}).get("frequency")
+        return a if freq == 111 else b
+
+    cfg = _two_radio_cfg({"default_radio": "local", "tx_mode": "bridge", "origin_tx": "all"})
+    with patch("repeater.config.get_radio_for_board", side_effect=fake_get):
+        radio, meta = build_radio_stack(cfg)
+
+    assert meta["origin_tx"] == "all"
+    assert radio.fabric.origin_tx == "all"
+
+
+def test_origin_tx_defaults_to_default():
+    a = _FakeRadio("a")
+    b = _FakeRadio("b")
+
+    def fake_get(board):
+        freq = (board.get("radio") or {}).get("frequency")
+        return a if freq == 111 else b
+
+    cfg = _two_radio_cfg({"default_radio": "local"})
+    with patch("repeater.config.get_radio_for_board", side_effect=fake_get):
+        radio, meta = build_radio_stack(cfg)
+
+    assert meta["origin_tx"] == "default"
+    assert getattr(radio.fabric, "origin_tx", "default") == "default"
+
+
+def test_origin_tx_invalid_rejected():
+    a = _FakeRadio("a")
+    b = _FakeRadio("b")
+
+    def fake_get(board):
+        freq = (board.get("radio") or {}).get("frequency")
+        return a if freq == 111 else b
+
+    cfg = _two_radio_cfg({"origin_tx": "broadcast"})
+    with patch("repeater.config.get_radio_for_board", side_effect=fake_get):
+        with pytest.raises(ValueError):
+            build_radio_stack(cfg)


### PR DESCRIPTION
## What

Config plumbing for `fabric.origin_tx: default | all` (mechanism in openhop-dev/openhop_core#124, API shape per openhop-dev/openhop_core#123):

- `build_radio_stack` reads the knob, validates it (`ValueError` on junk, same style as `tx_mode`), applies it on both fabric paths, and reports it in `meta`;
- a clear `RuntimeError` when `origin_tx: all` is configured but the installed openhop-core predates the feature;
- `origin_tx=%s` added to the "RF fabric active" startup log;
- documented in `config.yaml.example` next to `tx_mode`.

## Why

`tx_mode=bridge` steers forwards RX radio → the other radio, but locally originated packets (identity replies, companion DMs, own adverts) leave on the default radio only and never cross the link. `origin_tx: all` fans them out to every registered radio, sequentially in config order.

## Evidence

Bench-verified (control phase reproduced the bug: origins `TX local` only, zero frames on the link; with `all`: login across the bridge OK both directions, forwards unchanged) and running in production on our Czech-mesh internet bridge since 2026-08-24 — full chain observed including a mast repeater rebroadcasting the bridged advert on the far segment.

## Tests / gates

Three tests in `tests/test_multi_radio_stack.py`; the one touching `fabric.origin_tx` is `skipif`-gated on core capability (`hasattr(RFFabric, "set_origin_tx")`), so CI stays green until the core PR merges — verified against both patched core and current core dev (10 passed + 1 skipped). ruff check/format clean, bandit clean.
