### PR TITLE
Add per-message channel region overrides to Frame

### DIFF
--- a/repeater/companion/bridge.py
+++ b/repeater/companion/bridge.py
@@ -10,13 +10,36 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import re
 from collections.abc import Mapping
+from contextvars import ContextVar
 from enum import Enum
 from typing import Any, Callable, Optional
 
 from openhop_core.companion import CompanionBridge
+from openhop_core.protocol.constants import MAX_TEXT_LEN, PAYLOAD_TYPE_GRP_TXT, ROUTE_TYPE_FLOOD
+from openhop_core.protocol.packet import Packet
+from openhop_core.protocol.transport_keys import get_auto_key_for
 
 logger = logging.getLogger("RepeaterCompanionBridge")
+
+# One packet only: consumed before Core invokes the transport or any callbacks.
+_channel_region_scope: ContextVar[Optional[tuple[object, bytes]]] = ContextVar(
+    "companion_channel_region_scope", default=None
+)
+
+
+def normalize_region_name(value: str) -> str:
+    """Normalize a public auto-hashtag region, never arbitrary key material."""
+    if not isinstance(value, str):
+        raise ValueError("region must be a string")
+    region = value.strip().removeprefix("#")
+    if not region.isascii():
+        raise ValueError("region must contain only ASCII characters")
+    region = region.lower()
+    if re.fullmatch(r"[a-z0-9-]{1,30}", region, flags=re.ASCII) is None:
+        raise ValueError("region must contain 1-30 ASCII letters, digits, or hyphens")
+    return region
 
 
 def _prefs_bytes_from_json(value: Any) -> bytes:
@@ -93,6 +116,62 @@ class RepeaterCompanionBridge(CompanionBridge):
             radio_settings_getter=radio_settings_getter,
             max_tx_power_getter=max_tx_power_getter,
         )
+
+    def _apply_flood_scope(self, pkt: Packet) -> None:
+        pending = _channel_region_scope.get()
+        if pending is None or pending[0] is not self:
+            super()._apply_flood_scope(pkt)
+            return
+        # No shared scope mutation: nested sends and child tasks must not inherit
+        # this intent when the packet injector or a Core callback runs.
+        _channel_region_scope.set(None)
+        if (
+            pkt.get_payload_type() != PAYLOAD_TYPE_GRP_TXT
+            or pkt.get_route_type() != ROUTE_TYPE_FLOOD
+        ):
+            raise ValueError("region override requires a flood channel text packet")
+        self._scope_packet(pkt, pending[1])
+        pkt._flood_scope_applied = True
+
+    async def send_channel_message(
+        self,
+        channel_idx: int,
+        text: str,
+        timestamp: Optional[int] = None,
+        *,
+        region: Optional[str] = None,
+    ) -> bool:
+        """Optionally scope one channel message without changing radio defaults."""
+        if region is None:
+            return await super().send_channel_message(channel_idx, text, timestamp=timestamp)
+        region_key = get_auto_key_for(normalize_region_name(region))
+        if (
+            not isinstance(channel_idx, int)
+            or isinstance(channel_idx, bool)
+            or not 0 <= channel_idx <= 255
+        ):
+            raise ValueError("invalid channel index")
+        if not isinstance(text, str) or not text.strip() or "\x00" in text:
+            raise ValueError("text must be nonempty and contain no NUL characters")
+        if timestamp is not None and (
+            not isinstance(timestamp, int)
+            or isinstance(timestamp, bool)
+            or not 0 <= timestamp <= 0xFFFFFFFF
+        ):
+            raise ValueError("invalid channel timestamp")
+        # Keep this adjacent to Core's builder, with no await before it reads the
+        # sender name. New scoped sends reject truncation; legacy sends keep it.
+        max_bytes = max(0, MAX_TEXT_LEN - len(f"{self.prefs.node_name}: ".encode("utf-8")))
+        if len(text.encode("utf-8")) > max_bytes:
+            raise ValueError(f"text exceeds {max_bytes} UTF-8 bytes for the channel sender name")
+        token = _channel_region_scope.set((self, region_key))
+        try:
+            # Retain Core's full channel-secret encryption and echo tracking.
+            return await super().send_channel_message(channel_idx, text, timestamp=timestamp)
+        finally:
+            # Also clear intents when a channel is missing, construction fails,
+            # or transport cancellation interrupts the send.
+            _channel_region_scope.reset(token)
 
     def _save_prefs(self) -> None:
         """Persist full NodePrefs as JSON to SQLite."""

--- a/repeater/companion/frame_server.py
+++ b/repeater/companion/frame_server.py
@@ -10,11 +10,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import struct
 from typing import Optional
 
-from openhop_core.companion.constants import RESP_CODE_NO_MORE_MESSAGES
+from openhop_core.companion.constants import (
+    ERR_CODE_ILLEGAL_ARG,
+    ERR_CODE_NOT_FOUND,
+    MAX_FRAME_SIZE,
+    PUB_KEY_SIZE,
+    RESP_CODE_NO_MORE_MESSAGES,
+)
 from openhop_core.companion.frame_server import CompanionFrameServer as _BaseFrameServer
 from openhop_core.companion.models import QueuedMessage
+
+from repeater.companion.bridge import normalize_region_name
 
 logger = logging.getLogger("CompanionFrameServer")
 
@@ -53,6 +62,53 @@ class CompanionFrameServer(_BaseFrameServer):
             control_handler=control_handler,
         )
         self.sqlite_handler = sqlite_handler
+
+    async def _cmd_send_channel_txt_msg(self, data: bytes) -> None:
+        if data and data[0] == 0x81:
+            # A distinct response cannot be confused with an ordinary send's OK.
+            if data != b"\x81\x00\x00\x00\x00\x00":
+                self._write_err(ERR_CODE_ILLEGAL_ARG)
+                return
+            public_key = self.bridge.get_public_key()
+            if len(public_key) != PUB_KEY_SIZE:
+                self._write_err(ERR_CODE_ILLEGAL_ARG)
+                return
+            self._write_frame(b"\xf0OHREG1" + public_key)
+            return
+        if data and data[0] == 0x80:
+            # Count the command byte as part of the upstream Frame payload cap.
+            if len(data) < 9 or len(data) + 1 > MAX_FRAME_SIZE:
+                self._write_err(ERR_CODE_ILLEGAL_ARG)
+                return
+            channel_idx = data[1]
+            timestamp = struct.unpack("<I", data[2:6])[0]
+            region_length = data[6]
+            if not 1 <= region_length <= 30 or len(data) <= 7 + region_length:
+                self._write_err(ERR_CODE_ILLEGAL_ARG)
+                return
+            try:
+                region = data[7 : 7 + region_length].decode("ascii")
+                if normalize_region_name(region) != region:
+                    raise ValueError("wire region must be canonical")
+                text = data[7 + region_length :].decode("utf-8")
+                if not text.strip() or "\x00" in text:
+                    raise ValueError("invalid channel text")
+            except ValueError:
+                self._write_err(ERR_CODE_ILLEGAL_ARG)
+                return
+            if self.bridge.get_channel(channel_idx) is None:
+                self._write_err(ERR_CODE_NOT_FOUND)
+                return
+            try:
+                ok = await self.bridge.send_channel_message(
+                    channel_idx, text, timestamp=timestamp, region=region
+                )
+            except ValueError:
+                self._write_err(ERR_CODE_ILLEGAL_ARG)
+                return
+            self._write_ok() if ok else self._write_err(ERR_CODE_NOT_FOUND)
+            return
+        await super()._cmd_send_channel_txt_msg(data)
 
     async def start(self) -> None:
         """Start persistence before accepting companion client connections."""

--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -149,7 +149,9 @@ class RoomServer:
                 # match the daemon scheduler and the HTTP endpoint — reading
                 # only room_name here meant one CLI advert renamed the room
                 # on the mesh to the identity-name fallback.
-                node_name = room_settings.get("node_name", room_settings.get("room_name", room_name))
+                node_name = room_settings.get(
+                    "node_name", room_settings.get("room_name", room_name)
+                )
                 latitude = room_settings.get("latitude", 0.0)
                 longitude = room_settings.get("longitude", 0.0)
 

--- a/tests/test_companion_regions.py
+++ b/tests/test_companion_regions.py
@@ -1,0 +1,258 @@
+import asyncio
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from openhop_core.companion.constants import CMD_SEND_CHANNEL_TXT_MSG, RESP_CODE_ERR, RESP_CODE_OK
+from openhop_core.protocol import LocalIdentity
+from openhop_core.protocol.constants import ROUTE_TYPE_FLOOD, ROUTE_TYPE_TRANSPORT_FLOOD
+from openhop_core.protocol.packet_builder import PacketBuilder
+from openhop_core.protocol.transport_keys import calc_transport_code, get_auto_key_for
+
+from repeater.companion import bridge as bridge_module
+from repeater.companion.bridge import RepeaterCompanionBridge
+from repeater.companion.frame_server import CompanionFrameServer, _BaseFrameServer
+
+
+def _scoped_channel_body(region=b"usa", text=b"hello", channel_idx=1):
+    return (
+        bytes([0x80, channel_idx]) + struct.pack("<I", 123) + bytes([len(region)]) + region + text
+    )
+
+
+def _region_test_bridge(injector, *, node_name="Alice"):
+    bridge = RepeaterCompanionBridge(LocalIdentity(), injector, node_name=node_name)
+    # Nonzero upper half ensures the Core builder must use the complete secret.
+    assert bridge.set_channel(1, "test", bytes(range(32)))
+    return bridge
+
+
+@pytest.mark.asyncio
+async def test_scoped_channel_preserves_full_secret_and_echo_tracking():
+    packets = []
+
+    async def inject(packet, **_kwargs):
+        packets.append(packet)
+        return True
+
+    bridge = _region_test_bridge(inject)
+    bridge.set_flood_scope(get_auto_key_for("default"))
+
+    assert await bridge.send_channel_message(1, "hello", timestamp=123, region=" #USA ")
+    packet = packets[0]
+    expected = PacketBuilder.create_group_datagram(
+        "test", bridge._identity, "hello", "Alice", bridge.channels.get_channels(), timestamp=123
+    )
+    assert packet.get_payload() == expected.get_payload()
+    assert packet.get_route_type() == ROUTE_TYPE_TRANSPORT_FLOOD
+    assert packet.transport_codes == [calc_transport_code(get_auto_key_for("usa"), packet), 0]
+    assert packet._flood_scope_applied is True
+    assert bridge._check_and_track_group_packet(packet) is True
+    assert bridge._flood_transport_key == get_auto_key_for("default")
+
+
+@pytest.mark.asyncio
+async def test_scoped_channel_context_is_consumed_before_nested_or_concurrent_sends():
+    packets = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def inject(packet, **_kwargs):
+        packets.append(packet)
+        if len(packets) == 1:
+            # Same-task and child-task sends from an injector must not inherit it.
+            await bridge.send_channel_message(1, "nested", timestamp=124)
+            await asyncio.create_task(bridge.send_channel_message(1, "child", timestamp=125))
+            started.set()
+            await release.wait()
+        return True
+
+    bridge = _region_test_bridge(inject)
+    bridge.set_flood_scope(get_auto_key_for("default"))
+    task = asyncio.create_task(bridge.send_channel_message(1, "scoped", region="usa"))
+    await asyncio.wait_for(started.wait(), 1)
+    assert await bridge.send_channel_message(1, "parallel")
+    other = _region_test_bridge(inject)
+    assert await other.send_channel_message(1, "other")
+    release.set()
+    assert await task
+    assert packets[0].transport_codes[0] == calc_transport_code(get_auto_key_for("usa"), packets[0])
+    for packet in packets[1:4]:
+        assert packet.transport_codes[0] == calc_transport_code(get_auto_key_for("default"), packet)
+    assert packets[4].get_route_type() == ROUTE_TYPE_FLOOD
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["builder", "injector", "cancel"])
+async def test_scoped_channel_errors_and_cancellation_do_not_leak(failure):
+    packets = []
+    started = asyncio.Event()
+
+    async def inject(packet, **_kwargs):
+        packets.append(packet)
+        if len(packets) == 1 and failure != "builder":
+            started.set()
+            if failure == "cancel":
+                await asyncio.Event().wait()
+            raise RuntimeError("injection failed")
+        return True
+
+    bridge = _region_test_bridge(inject)
+    if failure == "builder":
+        with patch.object(
+            PacketBuilder, "create_group_datagram", side_effect=ValueError("builder")
+        ):
+            assert not await bridge.send_channel_message(1, "scoped", region="usa")
+    elif failure == "cancel":
+        task = asyncio.create_task(bridge.send_channel_message(1, "scoped", region="usa"))
+        await asyncio.wait_for(started.wait(), 1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        assert not await bridge.send_channel_message(1, "scoped", region="usa")
+    assert await bridge.send_channel_message(1, "normal")
+    assert packets[-1].get_route_type() == ROUTE_TYPE_FLOOD
+
+
+@pytest.mark.asyncio
+async def test_frame_regions_capability_and_scoped_send_use_existing_command():
+    packets = []
+
+    async def inject(packet, **_kwargs):
+        packets.append(packet)
+        return True
+
+    bridge = _region_test_bridge(inject)
+    server = CompanionFrameServer(bridge, "0x01", port=0)
+    server._write_frame = MagicMock()
+    await server._handle_cmd(bytes([CMD_SEND_CHANNEL_TXT_MSG, 0x81, 0, 0, 0, 0, 0]))
+    server._write_frame.assert_called_once_with(b"\xf0OHREG1" + bridge.get_public_key())
+    assert packets == []
+    server._write_frame.reset_mock()
+    await server._handle_cmd(bytes([CMD_SEND_CHANNEL_TXT_MSG]) + _scoped_channel_body())
+    server._write_frame.assert_called_once_with(bytes([RESP_CODE_OK]))
+    assert packets[0].transport_codes[0] == calc_transport_code(get_auto_key_for("usa"), packets[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"\x81",
+        b"\x81\x00\x00\x00\x00\x01",
+        b"\x81" + bytes(6),
+        _scoped_channel_body(region=b""),
+        _scoped_channel_body(region=b"a" * 31),
+        _scoped_channel_body(region=b"USA"),
+        _scoped_channel_body(region=b"#usa"),
+        _scoped_channel_body(region=b" usa"),
+        _scoped_channel_body(region=b"us_a"),
+        _scoped_channel_body(region=b"\xff"),
+        _scoped_channel_body(text=b""),
+        _scoped_channel_body(text=b" \t"),
+        _scoped_channel_body(text=b"hi\x00"),
+        _scoped_channel_body(text=b"\xff"),
+        _scoped_channel_body(text=b"x" * 166),
+        _scoped_channel_body(channel_idx=255),
+        b"\x80\x01" + bytes(4) + b"\x03us",
+    ],
+)
+async def test_frame_regions_invalid_input_never_reaches_rf(body):
+    injector = AsyncMock(return_value=True)
+    bridge = _region_test_bridge(injector)
+    server = CompanionFrameServer(bridge, "0x01", port=0)
+    server._write_frame = MagicMock()
+    await server._cmd_send_channel_txt_msg(body)
+    assert server._write_frame.call_args.args[0][0] == RESP_CODE_ERR
+    injector.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_frame_scoped_capacity_rejects_while_normal_keeps_legacy_truncation():
+    injector = AsyncMock(return_value=True)
+    bridge = _region_test_bridge(injector, node_name="N" * 31)
+    server = CompanionFrameServer(bridge, "0x01", port=0)
+    server._write_frame = MagicMock()
+    await server._cmd_send_channel_txt_msg(_scoped_channel_body(text=b"x" * 128))
+    assert server._write_frame.call_args.args[0][0] == RESP_CODE_ERR
+    injector.assert_not_awaited()
+    await server._cmd_send_channel_txt_msg(bytes([0, 1]) + bytes(4) + b"x" * 128)
+    assert server._write_frame.call_args.args[0] == bytes([RESP_CODE_OK])
+    injector.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_old_frame_server_rejects_scoped_subtypes_before_rf():
+    injector = AsyncMock(return_value=True)
+    bridge = _region_test_bridge(injector)
+    server = _BaseFrameServer(bridge, "0x01", port=0)
+    server._write_frame = MagicMock()
+    for body in (_scoped_channel_body(), bytes([0x81, 0, 0, 0, 0, 0])):
+        await server._cmd_send_channel_txt_msg(body)
+        assert server._write_frame.call_args.args[0][0] == RESP_CODE_ERR
+    injector.assert_not_awaited()
+
+
+@pytest.mark.parametrize("value,expected", [(" #USA-West ", "usa-west"), ("a" * 30, "a" * 30)])
+def test_region_name_normalizes_public_names(value, expected):
+    assert bridge_module.normalize_region_name(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, 123, "", "#", "a" * 31, "a_b", "a b", "é", "K", "a\x00"])
+def test_region_name_rejects_invalid_or_non_ascii_input(value):
+    with pytest.raises(ValueError):
+        bridge_module.normalize_region_name(value)
+
+
+@pytest.mark.asyncio
+async def test_scoped_frame_accepts_exact_maximum_frame_and_utf8_text():
+    injector = AsyncMock(return_value=True)
+    bridge = _region_test_bridge(injector, node_name="A")
+    server = CompanionFrameServer(bridge, "0x01", port=0)
+    server._write_frame = MagicMock()
+    # 1 command + 7 fixed bytes + 12 region + 156 text = 176.
+    body = _scoped_channel_body(region=b"a" * 12, text="é".encode() * 78)
+    assert len(body) + 1 == 176
+    await server._cmd_send_channel_txt_msg(body)
+    assert server._write_frame.call_args.args[0] == bytes([RESP_CODE_OK])
+    injector.assert_awaited_once()
+    injector.reset_mock()
+    await server._cmd_send_channel_txt_msg(body + b"x")
+    assert server._write_frame.call_args.args[0][0] == RESP_CODE_ERR
+    injector.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scoped_channel_missing_target_clears_intent_without_persisting_settings():
+    injector = AsyncMock(return_value=True)
+    bridge = _region_test_bridge(injector)
+    bridge._save_prefs = MagicMock()
+    assert not await bridge.send_channel_message(255, "missing", region="usa")
+    injector.assert_not_awaited()
+    assert await bridge.send_channel_message(1, "normal")
+    assert injector.call_args.args[0].get_route_type() == ROUTE_TYPE_FLOOD
+    bridge._save_prefs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_scoped_sends_keep_independent_regions():
+    packets = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def inject(packet, **_kwargs):
+        packets.append(packet)
+        if len(packets) == 1:
+            started.set()
+            await release.wait()
+        return True
+
+    bridge = _region_test_bridge(inject)
+    first = asyncio.create_task(bridge.send_channel_message(1, "first", region="usa"))
+    await asyncio.wait_for(started.wait(), 1)
+    assert await bridge.send_channel_message(1, "second", region="europe")
+    release.set()
+    assert await first
+    for packet, region in zip(packets, ("usa", "europe")):
+        assert packet.transport_codes[0] == calc_transport_code(get_auto_key_for(region), packet)


### PR DESCRIPTION
## Summary

Add a region override to a single outgoing channel text message without changing the companion's shared flood scope, preferences, or channel key.

This PR is based directly on `dev`: two runtime files implement the feature, with focused tests and one formatting-only change required by the repository-wide CI check. It does **not** import the Companion API fork, add dependencies, or change database/configuration schemas.

- Extend the Repeater bridge with an optional `region` argument. The existing Core builder still owns encryption (including 32-byte channel secrets), echo tracking, and sending.
- Consume a task-local scope in the packet-building hook before any transport await or callback. Ordinary sends and other clients retain their existing scope.
- Extend Frame command 3 with scoped subtype `0x80` and a read-only `0x81` capability probe. Subtype 0 remains unchanged. Older servers reject the extension before RF.

### Wire contract

- Probe: `[3, 0x81, 0, 0, 0, 0, 0]`
- Probe response: `[0xF0, ASCII "OHREG1", companion public key (32 bytes)]`
- Scoped send: `[3, 0x80, channel index, timestamp u32le, region length u8, canonical ASCII region, UTF-8 text]`
- Scoped sends use normal OK/ERR responses. Clients must not fall back or blindly retry an uncertain send.
- Regions contain 1–30 lowercase ASCII letters, digits, or hyphens; the complete Frame payload is capped at 176 bytes. Message capacity also accounts for the sender-name prefix.

## Verification

- 40 focused region cases, including concurrency, nested/child sends, cancellation/failure cleanup, missing targets, exact capability dispatch, malformed input, 32-byte channel secrets, and legacy command compatibility.
- 74 targeted companion tests passed.
- Repository-wide `pre-commit run --all-files` passed, including Ruff 0.15.14, Bandit, OpenAPI coverage, and the full pytest hook.
- All changed files parse with Python 3.9 grammar; runtime checks used Python 3.11.
- The same scoped-send implementation was exercised on a Pi through Frame and the separate API fork: scoped messages were transmitted and heard repeated with the correct transport code; a subsequent ordinary send did not inherit the override.

The initial Actions run found an existing Ruff formatting issue in `repeater/handler_helpers/room_server.py`, also reproduced on unmodified `dev`. Commit `ed8c375` wraps that single call; its Python AST is unchanged.

## Rollout / rollback

Clients must verify the magic and full companion identity on each new connection before enabling scoped sends. No migration is required. Reverting this PR restores the original behavior; updated clients fail closed against servers that do not advertise support.
