### PR TITLE
fix(companion): report real battery voltage in core stats

### DIFF
--- a/repeater/companion/frame_server.py
+++ b/repeater/companion/frame_server.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Optional
+import os
+import shutil
+from typing import Callable, Optional
 
 from openhop_core.companion.constants import RESP_CODE_NO_MORE_MESSAGES
 from openhop_core.companion.frame_server import CompanionFrameServer as _BaseFrameServer
@@ -38,6 +40,8 @@ class CompanionFrameServer(_BaseFrameServer):
         local_hash: Optional[int] = None,
         stats_getter=None,
         control_handler=None,
+        batt_getter: Optional[Callable[[], int]] = None,
+        storage_dir: Optional[str] = None,
     ):
         super().__init__(
             bridge=bridge,
@@ -53,6 +57,37 @@ class CompanionFrameServer(_BaseFrameServer):
             control_handler=control_handler,
         )
         self.sqlite_handler = sqlite_handler
+        self.batt_getter = batt_getter
+        self.storage_dir = storage_dir
+
+    def _get_batt_and_storage(self) -> tuple[int, int, int]:
+        """Report battery millivolts and storage usage to companion clients.
+
+        The base-class hook returns zeros, so companion apps show no battery and
+        no storage for a Python repeater. Battery comes from whichever sensor
+        plug-in publishes one (an attached UPS HAT, or the battery of an
+        openHop modem the repeater drives); storage is the filesystem holding
+        the repeater's data directory.
+        """
+        millivolts = 0
+        if self.batt_getter is not None:
+            try:
+                millivolts = int(self.batt_getter() or 0)
+            except Exception:  # pragma: no cover - never break the companion link
+                logger.debug("battery lookup failed", exc_info=True)
+                millivolts = 0
+        if millivolts < 0 or millivolts > 0xFFFF:
+            millivolts = 0
+
+        used_kb = total_kb = 0
+        if self.storage_dir:
+            try:
+                usage = shutil.disk_usage(self.storage_dir)
+                total_kb = min(usage.total // 1024, 0xFFFFFFFF)
+                used_kb = min((usage.total - usage.free) // 1024, 0xFFFFFFFF)
+            except OSError:
+                logger.debug("storage lookup failed for %s", self.storage_dir, exc_info=True)
+        return millivolts, used_kb, total_kb
 
     async def start(self) -> None:
         """Start persistence before accepting companion client connections."""

--- a/repeater/companion/frame_server.py
+++ b/repeater/companion/frame_server.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import shutil
 from typing import Callable, Optional
 
@@ -40,8 +39,8 @@ class CompanionFrameServer(_BaseFrameServer):
         local_hash: Optional[int] = None,
         stats_getter=None,
         control_handler=None,
-        batt_getter: Optional[Callable[[], int]] = None,
-        storage_dir: Optional[str] = None,
+        batt_getter: Callable[[], int] | None = None,
+        storage_dir: str | None = None,
     ):
         super().__init__(
             bridge=bridge,

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import logging
+import math
 import os
 import signal
 import socket
@@ -1490,9 +1491,12 @@ class RepeaterDaemon:
                 except (TypeError, ValueError):
                     continue
             try:
-                millivolts = round(float(millivolts))
-            except (TypeError, ValueError):
+                millivolts = float(millivolts)
+            except (TypeError, ValueError, OverflowError):
                 continue
+            if not math.isfinite(millivolts):
+                continue
+            millivolts = round(millivolts)
 
             # The core-stats frame packs battery_mv as an unsigned 16-bit int.
             if 0 < millivolts <= 0xFFFF:

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -26,6 +26,7 @@ from repeater.config import (
     NullRadio,
     build_radio_stack,
     load_config,
+    resolve_storage_dir,
     save_config,
 )
 from repeater.config_manager import ConfigManager
@@ -1449,8 +1450,12 @@ class RepeaterDaemon:
     def _companion_storage_dir(self) -> "str | None":
         """Filesystem path companion clients should see storage figures for."""
         try:
-            path = (self.config.get("storage", {}) or {}).get("storage_dir")
-            return path if path and os.path.isdir(path) else None
+            return str(
+                resolve_storage_dir(
+                    self.config,
+                    config_path=getattr(self, "config_path", None),
+                )
+            )
         except Exception:  # pragma: no cover - defensive
             return None
 

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -957,6 +957,8 @@ class RepeaterDaemon:
                     sqlite_handler=sqlite_handler,
                     local_hash=self.local_hash,
                     stats_getter=self._get_companion_stats,
+                    batt_getter=self._companion_battery_mv,
+                    storage_dir=self._companion_storage_dir(),
                     control_handler=(
                         self.discovery_helper.control_handler if self.discovery_helper else None
                     ),
@@ -1198,6 +1200,8 @@ class RepeaterDaemon:
             sqlite_handler=sqlite_handler,
             local_hash=self.local_hash,
             stats_getter=self._get_companion_stats,
+            batt_getter=self._companion_battery_mv,
+            storage_dir=self._companion_storage_dir(),
             control_handler=(
                 self.discovery_helper.control_handler if self.discovery_helper else None
             ),
@@ -1440,6 +1444,14 @@ class RepeaterDaemon:
             stats["radio_error"] = self.radio_error
 
         return stats
+
+    def _companion_storage_dir(self) -> "str | None":
+        """Filesystem path companion clients should see storage figures for."""
+        try:
+            path = (self.config.get("storage", {}) or {}).get("storage_dir")
+            return path if path and os.path.isdir(path) else None
+        except Exception:  # pragma: no cover - defensive
+            return None
 
     def _companion_battery_mv(self) -> int:
         """Battery voltage in mV for the companion core-stats frame.

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -1441,6 +1441,52 @@ class RepeaterDaemon:
 
         return stats
 
+    def _companion_battery_mv(self) -> int:
+        """Battery voltage in mV for the companion core-stats frame.
+
+        MeshCore companion clients show the battery of the device they are
+        connected to. A Python repeater has no battery of its own, but a sensor
+        plug-in often reports one -- an attached UPS HAT, or the battery of an
+        openHop modem the repeater is driving -- so surface the first sensor
+        publishing a usable voltage instead of always reporting 0.
+
+        Returns 0 when nothing is available, which is what clients already
+        expect for a mains-powered node.
+        """
+        if not self.sensor_manager:
+            return 0
+        try:
+            readings = (self.sensor_manager.get_summary() or {}).get("readings") or []
+        except Exception:  # pragma: no cover - defensive; stats must never raise
+            logger.debug("companion battery lookup failed", exc_info=True)
+            return 0
+
+        for reading in readings:
+            if not isinstance(reading, dict) or not reading.get("ok"):
+                continue
+            data = reading.get("data")
+            if not isinstance(data, dict):
+                continue
+
+            millivolts = data.get("battery_voltage_mv")
+            if millivolts is None:
+                volts = data.get("battery_voltage_v")
+                if volts is None:
+                    continue
+                try:
+                    millivolts = float(volts) * 1000.0
+                except (TypeError, ValueError):
+                    continue
+            try:
+                millivolts = round(float(millivolts))
+            except (TypeError, ValueError):
+                continue
+
+            # The core-stats frame packs battery_mv as an unsigned 16-bit int.
+            if 0 < millivolts <= 0xFFFF:
+                return millivolts
+        return 0
+
     async def _get_companion_stats(self, stats_type: int) -> dict:
         """Return stats dict for companion CMD_GET_STATS (format expected by frame_server + meshcore_py)."""
         from repeater.companion.constants import (
@@ -1459,7 +1505,7 @@ class RepeaterDaemon:
             queue_len += getattr(getattr(bridge, "message_queue", None), "count", 0) or 0
         if stats_type == STATS_TYPE_CORE:
             return {
-                "battery_mv": 0,
+                "battery_mv": self._companion_battery_mv(),
                 "uptime_secs": uptime_secs,
                 "errors": 0,
                 "queue_len": min(255, queue_len),

--- a/tests/test_companion_battery_mv.py
+++ b/tests/test_companion_battery_mv.py
@@ -5,7 +5,15 @@ connected device's battery. The repeater used to hardcode 0, so companion apps
 always showed no battery even when a sensor plug-in was reporting one.
 """
 
+import struct
 from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from openhop_core.companion.constants import (
+    CMD_GET_BATT_AND_STORAGE,
+    RESP_CODE_BATT_AND_STORAGE,
+)
 
 from repeater.main import RepeaterDaemon
 
@@ -65,6 +73,9 @@ def test_ignores_out_of_range_and_unparseable_values():
         {"battery_voltage_mv": 70000},
         {"battery_voltage_mv": "n/a"},
         {"battery_voltage_v": None},
+        {"battery_voltage_mv": float("nan")},
+        {"battery_voltage_mv": float("inf")},
+        {"battery_voltage_v": float("-inf")},
     ):
         assert _daemon([_reading("modem", data)])._companion_battery_mv() == 0
 
@@ -113,3 +124,26 @@ def test_frame_server_without_getters_returns_zeros():
     fs.batt_getter = None
     fs.storage_dir = None
     assert fs._get_batt_and_storage() == (0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_get_batt_and_storage_command_dispatches_real_values(tmp_path):
+    """Exercise the real command registry and response-frame encoding path."""
+    from repeater.companion.frame_server import CompanionFrameServer
+
+    fs = CompanionFrameServer(
+        bridge=SimpleNamespace(),
+        companion_hash="test",
+        batt_getter=lambda: 4221,
+        storage_dir=str(tmp_path),
+    )
+    fs._write_frame = MagicMock()
+
+    await fs._handle_cmd(bytes([CMD_GET_BATT_AND_STORAGE]))
+
+    frame = fs._write_frame.call_args.args[0]
+    response_code, millivolts, used_kb, total_kb = struct.unpack("<BHII", frame)
+    assert response_code == RESP_CODE_BATT_AND_STORAGE
+    assert millivolts == 4221
+    assert total_kb > 0
+    assert 0 <= used_kb <= total_kb

--- a/tests/test_companion_battery_mv.py
+++ b/tests/test_companion_battery_mv.py
@@ -1,0 +1,78 @@
+"""Companion core-stats battery reporting.
+
+The MeshCore companion frame packs ``battery_mv``; clients show it as the
+connected device's battery. The repeater used to hardcode 0, so companion apps
+always showed no battery even when a sensor plug-in was reporting one.
+"""
+
+from types import SimpleNamespace
+
+from repeater.main import RepeaterDaemon
+
+
+def _base_config():
+    return {
+        "repeater": {
+            "node_name": "node-test",
+            "mode": "forward",
+            "latitude": 1.0,
+            "longitude": 2.0,
+        },
+        "logging": {"level": "INFO"},
+    }
+
+
+def _daemon(readings=None):
+    daemon = RepeaterDaemon(_base_config(), radio=object())
+    daemon.sensor_manager = (
+        None if readings is None else SimpleNamespace(get_summary=lambda: {"readings": readings})
+    )
+    return daemon
+
+
+def _reading(name, data, ok=True):
+    return {"name": name, "type": name, "ok": ok, "timestamp": "t", "data": data}
+
+
+def test_returns_zero_without_a_sensor_manager():
+    assert _daemon()._companion_battery_mv() == 0
+
+
+def test_reads_battery_voltage_mv():
+    daemon = _daemon([_reading("modem", {"battery_voltage_mv": 4213})])
+    assert daemon._companion_battery_mv() == 4213
+
+
+def test_derives_millivolts_from_volts():
+    daemon = _daemon([_reading("modem", {"battery_voltage_v": 3.72})])
+    assert daemon._companion_battery_mv() == 3720
+
+
+def test_skips_failed_and_batteryless_readings():
+    daemon = _daemon(
+        [
+            _reading("broken", {"battery_voltage_mv": 4100}, ok=False),
+            _reading("system-health", {"cpu_percent": 12.0}),
+            _reading("modem", {"battery_voltage_mv": 3980}),
+        ]
+    )
+    assert daemon._companion_battery_mv() == 3980
+
+
+def test_ignores_out_of_range_and_unparseable_values():
+    for data in (
+        {"battery_voltage_mv": 0},
+        {"battery_voltage_mv": 70000},
+        {"battery_voltage_mv": "n/a"},
+        {"battery_voltage_v": None},
+    ):
+        assert _daemon([_reading("modem", data)])._companion_battery_mv() == 0
+
+
+def test_never_raises_when_the_sensor_manager_misbehaves():
+    def boom():
+        raise RuntimeError("sensor manager exploded")
+
+    daemon = RepeaterDaemon(_base_config(), radio=object())
+    daemon.sensor_manager = SimpleNamespace(get_summary=boom)
+    assert daemon._companion_battery_mv() == 0

--- a/tests/test_companion_battery_mv.py
+++ b/tests/test_companion_battery_mv.py
@@ -89,6 +89,23 @@ def test_never_raises_when_the_sensor_manager_misbehaves():
     assert daemon._companion_battery_mv() == 0
 
 
+def test_companion_storage_dir_uses_default_path():
+    assert _daemon()._companion_storage_dir() == "/var/lib/openhop_repeater"
+
+
+def test_companion_storage_dir_supports_legacy_top_level_setting(tmp_path):
+    daemon = _daemon()
+    daemon.config["storage_dir"] = str(tmp_path)
+    assert daemon._companion_storage_dir() == str(tmp_path)
+
+
+def test_companion_storage_dir_resolves_relative_to_config(tmp_path):
+    daemon = _daemon()
+    daemon.config["storage"] = {"storage_dir": "data"}
+    daemon.__dict__["config_path"] = str(tmp_path / "config.yaml")
+    assert daemon._companion_storage_dir() == str(tmp_path / "data")
+
+
 def test_frame_server_reports_battery_and_storage(tmp_path):
     """The companion BATT_AND_STORAGE hook must return real values, not zeros."""
     from repeater.companion.frame_server import CompanionFrameServer

--- a/tests/test_companion_battery_mv.py
+++ b/tests/test_companion_battery_mv.py
@@ -76,3 +76,40 @@ def test_never_raises_when_the_sensor_manager_misbehaves():
     daemon = RepeaterDaemon(_base_config(), radio=object())
     daemon.sensor_manager = SimpleNamespace(get_summary=boom)
     assert daemon._companion_battery_mv() == 0
+
+
+def test_frame_server_reports_battery_and_storage(tmp_path):
+    """The companion BATT_AND_STORAGE hook must return real values, not zeros."""
+    from repeater.companion.frame_server import CompanionFrameServer
+
+    fs = CompanionFrameServer.__new__(CompanionFrameServer)
+    fs.batt_getter = lambda: 4221
+    fs.storage_dir = str(tmp_path)
+
+    mv, used_kb, total_kb = fs._get_batt_and_storage()
+    assert mv == 4221
+    assert total_kb > 0
+    assert 0 <= used_kb <= total_kb
+
+
+def test_frame_server_battery_survives_a_broken_getter(tmp_path):
+    from repeater.companion.frame_server import CompanionFrameServer
+
+    fs = CompanionFrameServer.__new__(CompanionFrameServer)
+
+    def boom():
+        raise RuntimeError("sensor exploded")
+
+    fs.batt_getter = boom
+    fs.storage_dir = str(tmp_path)
+    mv, _, _ = fs._get_batt_and_storage()
+    assert mv == 0
+
+
+def test_frame_server_without_getters_returns_zeros():
+    from repeater.companion.frame_server import CompanionFrameServer
+
+    fs = CompanionFrameServer.__new__(CompanionFrameServer)
+    fs.batt_getter = None
+    fs.storage_dir = None
+    assert fs._get_batt_and_storage() == (0, 0, 0)


### PR DESCRIPTION
Fixes #420.

## Summary

MeshCore companion clients previously received `battery_mv: 0` from the Python repeater even when a configured sensor reported a battery. This change surfaces real battery telemetry and implements the companion battery/storage command with repeater storage figures.

## Changes

- Adds `RepeaterDaemon._companion_battery_mv()` and returns its value in `STATS_TYPE_CORE`.
- Accepts `battery_voltage_mv` or converts `battery_voltage_v` to millivolts.
- Skips failed, missing, malformed, non-finite, zero, negative, and out-of-`uint16` readings.
- Returns `0` on unavailable data or sensor errors so stats cannot break the companion connection.
- Overrides the openhop_core `_get_batt_and_storage()` hook to report battery voltage plus used and total storage in KiB.
- Wires the battery getter and storage directory into companions created during startup and at runtime.
- Resolves storage through the canonical `resolve_storage_dir()` path, preserving nested configuration, the legacy top-level setting, the default path, and paths relative to the config file.

This supports batteries reported by sensor plug-ins such as `openhop_modem`, `waveshare_ups_d`, `lafvin_ups_3s`, and `ina219`.

## Verification

- 13 focused battery/storage tests pass.
- 24 companion, frame-server, and Python compatibility tests pass.
- Actual `CMD_GET_BATT_AND_STORAGE` dispatch and response encoding are covered.
- Ruff F/I checks, Ruff formatting, and `git diff --check` pass for the changed files.
- The full suite currently reaches the same unrelated `test_send_advert_paths` expectation failure present on `dev` (`Advert sent successfully` versus `Flood advert sent successfully`).

`errors: 0` in core stats remains unchanged because there is no established source of truth for it.