### PR TITLE
fix(sensors): normalize openHop Modem power telemetry

### DIFF
--- a/repeater/handler_helpers/protocol_request.py
+++ b/repeater/handler_helpers/protocol_request.py
@@ -358,8 +358,11 @@ class ProtocolRequestHelper:
         power = data.get("power_mw")
         if power is not None:
             try:
-                out.extend(encode_power(channel, int(float(power) / 1000.0)))
-            except (TypeError, ValueError):
+                power_mw = float(power)
+                watts = int(power_mw / 1000.0)
+                if power_mw >= 0.0 and watts <= 0xFFFF:
+                    out.extend(encode_power(channel, watts))
+            except (TypeError, ValueError, OverflowError):
                 pass
         return bytes(out)
 

--- a/repeater/sensors/openhop_modem.py
+++ b/repeater/sensors/openhop_modem.py
@@ -197,11 +197,14 @@ class OpenHopModemSensor(SensorBase):
             "battery_percent",
             "battery_percentage",
             "solar_charge_rate_percent_per_hour",
+            "bus_voltage_v",
+            "current_ma",
+            "power_mw",
         ):
             if key in payload:
                 out[key] = payload[key]
 
-        for key in ("battery_voltage_mv", "battery_voltage_v"):
+        for key in ("battery_voltage_mv", "battery_voltage_v", "current_ma", "power_mw"):
             if out.get(key) is None and system.get(key) is not None:
                 out[key] = system[key]
 

--- a/repeater/sensors/openhop_modem.py
+++ b/repeater/sensors/openhop_modem.py
@@ -197,16 +197,37 @@ class OpenHopModemSensor(SensorBase):
             "battery_percent",
             "battery_percentage",
             "solar_charge_rate_percent_per_hour",
-            "bus_voltage_v",
-            "current_ma",
-            "power_mw",
         ):
             if key in payload:
                 out[key] = payload[key]
 
-        for key in ("battery_voltage_mv", "battery_voltage_v", "current_ma", "power_mw"):
+        for key in ("bus_voltage_v", "current_ma", "power_mw"):
+            value = self._float(payload.get(key))
+            if value is not None:
+                out[key] = value
+
+        for key in ("battery_voltage_mv", "battery_voltage_v"):
             if out.get(key) is None and system.get(key) is not None:
                 out[key] = system[key]
+
+        station_g3_fallbacks = {
+            "bus_voltage_v": ("bus_voltage_v", "station_g3_input_voltage_v"),
+            "current_ma": ("current_ma", "station_g3_current_ma"),
+            "power_mw": ("power_mw",),
+        }
+        for output_key, system_keys in station_g3_fallbacks.items():
+            if out.get(output_key) is not None:
+                continue
+            for system_key in system_keys:
+                value = self._float(system.get(system_key))
+                if value is not None:
+                    out[output_key] = value
+                    break
+
+        if out.get("power_mw") is None:
+            power_w = self._float(system.get("station_g3_power_w"))
+            if power_w is not None:
+                out["power_mw"] = power_w * 1000.0
 
         if "battery_percent" not in out:
             battery_voltage_v = self._float(out.get("battery_voltage_v"))

--- a/repeater/sensors/openhop_modem.py
+++ b/repeater/sensors/openhop_modem.py
@@ -210,25 +210,6 @@ class OpenHopModemSensor(SensorBase):
             if out.get(key) is None and system.get(key) is not None:
                 out[key] = system[key]
 
-        station_g3_fallbacks = {
-            "bus_voltage_v": ("bus_voltage_v", "station_g3_input_voltage_v"),
-            "current_ma": ("current_ma", "station_g3_current_ma"),
-            "power_mw": ("power_mw",),
-        }
-        for output_key, system_keys in station_g3_fallbacks.items():
-            if out.get(output_key) is not None:
-                continue
-            for system_key in system_keys:
-                value = self._float(system.get(system_key))
-                if value is not None:
-                    out[output_key] = value
-                    break
-
-        if out.get("power_mw") is None:
-            power_w = self._float(system.get("station_g3_power_w"))
-            if power_w is not None:
-                out["power_mw"] = power_w * 1000.0
-
         if "battery_percent" not in out:
             battery_voltage_v = self._float(out.get("battery_voltage_v"))
             if battery_voltage_v is None:

--- a/tests/test_handler_helpers_path_protocol_text.py
+++ b/tests/test_handler_helpers_path_protocol_text.py
@@ -774,6 +774,41 @@ def test_telemetry_admin_full_mask_includes_environment_sensors():
     assert lpp == expected
 
 
+def test_station_g3_subwatt_power_uses_lpp_one_watt_resolution():
+    sm = _FakeSensorManager([_reading(bus_voltage_v=12.46, current_ma=59.7, power_mw=744.0)])
+    helper = ProtocolRequestHelper(
+        identity_manager=MagicMock(), packet_injector=AsyncMock(), sensor_manager=sm
+    )
+    admin = SimpleNamespace(is_guest=lambda: False)
+
+    lpp = helper._handle_get_telemetry(admin, 0, b"\x00")
+
+    expected = (
+        encode_voltage(TELEM_CHANNEL_SELF, 12.46)
+        + encode_voltage(TELEM_CHANNEL_SELF + 1, 12.46)
+        + encode_current(TELEM_CHANNEL_SELF + 1, 0.0597)
+        + encode_power(TELEM_CHANNEL_SELF + 1, 0)
+    )
+    assert lpp == expected
+
+
+def test_negative_power_is_preserved_as_current_but_omitted_from_unsigned_lpp_power():
+    sm = _FakeSensorManager([_reading(bus_voltage_v=12.46, current_ma=-59.7, power_mw=-744.0)])
+    helper = ProtocolRequestHelper(
+        identity_manager=MagicMock(), packet_injector=AsyncMock(), sensor_manager=sm
+    )
+    admin = SimpleNamespace(is_guest=lambda: False)
+
+    lpp = helper._handle_get_telemetry(admin, 0, b"\x00")
+
+    expected = (
+        encode_voltage(TELEM_CHANNEL_SELF, 12.46)
+        + encode_voltage(TELEM_CHANNEL_SELF + 1, 12.46)
+        + encode_current(TELEM_CHANNEL_SELF + 1, -0.0597)
+    )
+    assert lpp == expected
+
+
 def test_telemetry_bme280_emits_temperature_humidity_and_pressure_on_one_channel():
     """A BME280-shaped reading emits all three measured values on one channel.
 

--- a/tests/test_openhop_modem_sensor.py
+++ b/tests/test_openhop_modem_sensor.py
@@ -137,6 +137,69 @@ def test_openhop_modem_sensor_accepts_legacy_token_flag():
     assert data["token_configured"] is True
 
 
+def test_openhop_modem_sensor_prefers_top_level_power_telemetry():
+    sensor = OpenHopModemSensor("modem", {"settings": {"base_url": "http://modem.local"}})
+
+    data = sensor._normalize_payload(
+        {
+            "bus_voltage_v": 12.46,
+            "current_ma": 59.7,
+            "power_mw": 744.0,
+            "system": {
+                "station_g3_input_voltage_v": 11.0,
+                "station_g3_current_ma": 50.0,
+                "station_g3_power_w": 0.55,
+            },
+        }
+    )
+
+    assert data["bus_voltage_v"] == 12.46
+    assert data["current_ma"] == 59.7
+    assert data["power_mw"] == 744.0
+
+
+def test_openhop_modem_sensor_falls_back_to_legacy_station_g3_power_fields():
+    sensor = OpenHopModemSensor("modem", {"settings": {"base_url": "http://modem.local"}})
+
+    data = sensor._normalize_payload(
+        {
+            "bus_voltage_v": None,
+            "current_ma": None,
+            "power_mw": None,
+            "system": {
+                "station_g3_input_voltage_v": "12.46",
+                "station_g3_current_ma": "-59.7",
+                "station_g3_power_w": "-0.744",
+            },
+        }
+    )
+
+    assert data["bus_voltage_v"] == 12.46
+    assert data["current_ma"] == -59.7
+    assert data["power_mw"] == -744.0
+
+
+def test_openhop_modem_sensor_omits_invalid_power_telemetry():
+    sensor = OpenHopModemSensor("modem", {"settings": {"base_url": "http://modem.local"}})
+
+    data = sensor._normalize_payload(
+        {
+            "bus_voltage_v": "invalid",
+            "current_ma": "invalid",
+            "power_mw": "invalid",
+            "system": {
+                "station_g3_input_voltage_v": None,
+                "station_g3_current_ma": None,
+                "station_g3_power_w": None,
+            },
+        }
+    )
+
+    assert "bus_voltage_v" not in data
+    assert "current_ma" not in data
+    assert "power_mw" not in data
+
+
 def test_legacy_pymc_modem_module_and_registry_create_canonical_sensor():
     assert PymcModemSensor is OpenHopModemSensor
     legacy = SensorRegistry.create(

--- a/tests/test_openhop_modem_sensor.py
+++ b/tests/test_openhop_modem_sensor.py
@@ -158,14 +158,11 @@ def test_openhop_modem_sensor_prefers_top_level_power_telemetry():
     assert data["power_mw"] == 744.0
 
 
-def test_openhop_modem_sensor_falls_back_to_legacy_station_g3_power_fields():
+def test_openhop_modem_sensor_ignores_legacy_station_g3_power_fields():
     sensor = OpenHopModemSensor("modem", {"settings": {"base_url": "http://modem.local"}})
 
     data = sensor._normalize_payload(
         {
-            "bus_voltage_v": None,
-            "current_ma": None,
-            "power_mw": None,
             "system": {
                 "station_g3_input_voltage_v": "12.46",
                 "station_g3_current_ma": "-59.7",
@@ -174,9 +171,9 @@ def test_openhop_modem_sensor_falls_back_to_legacy_station_g3_power_fields():
         }
     )
 
-    assert data["bus_voltage_v"] == 12.46
-    assert data["current_ma"] == -59.7
-    assert data["power_mw"] == -744.0
+    assert "bus_voltage_v" not in data
+    assert "current_ma" not in data
+    assert "power_mw" not in data
 
 
 def test_openhop_modem_sensor_omits_invalid_power_telemetry():


### PR DESCRIPTION
## Summary

Normalize generic power readings from the openHop Modem HTTP sensor so Repeater telemetry consumes the top-level fields provided by openhop-dev/openhop_modem#69:

- `bus_voltage_v`
- `current_ma`
- `power_mw`

## Behavior

- Consume only the new generic top-level modem fields.
- Intentionally ignore the legacy Station G3-specific fields under `system.station_g3_*`.
- Reject invalid power values instead of passing strings through the sensor cache.
- Preserve signed current and power in sensor JSON.
- Skip negative power when encoding the unsigned Cayenne LPP power field.

Cayenne LPP power uses 1 W resolution. A Station G3 reading such as 744 mW therefore encodes as 0 W, while its voltage/current entries and the full-resolution sensor JSON remain available.

## Tests

Added coverage for:

- new top-level modem fields;
- ignoring legacy Station G3-specific fields;
- invalid-value omission;
- sub-watt LPP encoding; and
- negative-power handling.

Verified on Python 3.12:

- 37 focused sensor/protocol tests pass.
- Changed files pass scoped Ruff lint and format checks.
- Strict OpenAPI contract check passes.
- `git diff --check` passes.

The repository-wide pytest run still has the existing `test_send_advert_paths` failure against the current moving openHop Core dev revision `77f116a8dab097642d04a16c8aaf097c0dd33cc3`; the same failure reproduces unchanged on Repeater dev. The repository-wide Ruff format check likewise reports pre-existing formatting drift in `room_server.py`; this PR does not modify that file.
