### PR TITLE
feat(mqtt): optionally publish this node's own transmissions

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -701,6 +701,22 @@ mqtt_brokers:
   #   enabled: true|false # Enable TLS. If the endpoint's certificate is self-signed, the Root CA should be added to the OS's certificate store. 
   #   insecure: true|false # Validate TLS certificates
 
+  # publish_tx: off|advert|on
+  #   Publish this node's OWN transmissions, in addition to what it receives.
+  #   The radio is half-duplex, so a node never hears its own transmission --
+  #   meaning a packet this node relays can never appear in what it publishes.
+  #   Without this, a repeater's relays are invisible to aggregators (CoreScope,
+  #   MeshMapper, LetsMesh) unless a second observer node is in radio range.
+  #     off    - never publish own transmissions (default; unchanged behaviour)
+  #     advert - publish only this node's own adverts
+  #     on     - publish every packet this node transmits, including relays
+  #   YAML resolves bare on/off to booleans; both those and the quoted strings
+  #   ("on"/"off") are accepted, as are true/false.
+  #   Own-TX records are sent with "direction": "tx" and carry the forwarded
+  #   bytes (which include this node's path hash). SNR/RSSI are reported as 0,
+  #   since a node cannot measure the signal of its own transmission.
+  # publish_tx: off
+
   # Block specific packet types from being published to the MQTT endpoint
   # If not specified or empty list, all types are published
   # Available types: REQ, RESPONSE, TXT_MSG, ACK, ADVERT, GRP_TXT,

--- a/repeater/data_acquisition/mqtt_handler.py
+++ b/repeater/data_acquisition/mqtt_handler.py
@@ -1082,6 +1082,12 @@ class MeshCoreToMqttPusher:
                             f"Skipped own-TX publish to {conn.broker['name']} "
                             f"(publish_tx={conn.publish_tx})"
                         )
+                        # Record the deliberate skip, matching the disabled-broker
+                        # convention below. Without this a tx record that every
+                        # broker declines leaves ``results`` empty and trips the
+                        # "No active broker connections" warning, which points
+                        # operators at a connectivity problem that does not exist.
+                        results.append((conn.broker["name"], "Skipped: publish_tx"))
                         continue
                     result = conn.publish(subtopic, message, retain=retain, qos=qos)
                     results.append((conn.broker["name"], result))

--- a/repeater/data_acquisition/mqtt_handler.py
+++ b/repeater/data_acquisition/mqtt_handler.py
@@ -22,10 +22,47 @@ except ImportError:
 
 logger = logging.getLogger("MQTTHandler")
 
+# PAYLOAD_TYPES code for ADVERT; used by the per-broker ``publish_tx: advert`` mode.
+ADVERT_PAYLOAD_TYPE = 4
+
 # Custom ultra-verbose level for high-frequency per-broker publish logs.
 # Keeps default DEBUG useful while allowing deep diagnostics when needed.
 TRACE_LEVEL = 5
 logging.addLevelName(TRACE_LEVEL, "TRACE")
+
+
+def _normalize_publish_tx(value: Any, broker_name: Optional[str] = None) -> str:
+    """Normalize a ``publish_tx`` setting to one of ``off``/``advert``/``on``.
+
+    YAML 1.1 (which PyYAML implements) resolves bare ``on``/``off`` to booleans,
+    so ``publish_tx: on`` reaches us as ``True`` rather than the string "on".
+    Quoted forms and the equivalent ``true``/``false`` spellings are accepted
+    too. Anything unrecognized fails closed to ``off`` so a typo can never
+    silently start uplinking this node's traffic.
+    """
+    if value is None:
+        return "off"
+    if isinstance(value, bool):
+        return "on" if value else "off"
+
+    text = str(value).strip().lower()
+    if text in ("on", "true", "yes"):
+        return "on"
+    if text in ("off", "false", "no"):
+        return "off"
+    if text == "advert":
+        return "advert"
+
+    logger.warning(f"Invalid publish_tx '{value}' for {broker_name}, defaulting to 'off'")
+    return "off"
+
+
+def _coerce_packet_type(value: Any) -> Optional[int]:
+    """Best-effort int for a PacketRecord ``packet_type`` (serialized as a string)."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _trace(message: str):
@@ -270,6 +307,22 @@ class _BrokerConnection:
         self.disallowed_types = [
             val for val in self.disallowed_types if val is not None
         ]  # Filter out invalid names
+
+        # Whether this broker receives this node's *own* transmissions.
+        #   off    - never (default; preserves historical behaviour)
+        #   advert - only this node's own adverts
+        #   on     - every packet this node transmits, including relays
+        # A half-duplex radio cannot hear itself, so without this a repeater's
+        # relays are invisible to aggregators unless a second observer is in range.
+        self.publish_tx = _normalize_publish_tx(broker.get("publish_tx"), broker.get("name"))
+
+    def allows_tx_packet(self, packet_type: Optional[int]) -> bool:
+        """Whether a self-reported TX payload of this type may go to this broker."""
+        if self.publish_tx == "on":
+            return True
+        if self.publish_tx == "advert":
+            return packet_type == ADVERT_PAYLOAD_TYPE
+        return False
 
     def _generate_jwt(self) -> str:
         """Generate MeshCore-style Ed25519 JWT token"""
@@ -944,6 +997,15 @@ class MeshCoreToMqttPusher:
     def publish_packet(self, pkt: dict, subtopic="packets", retain=False):
         return self.publish(subtopic, self._process_packet(pkt), retain)
 
+    def wants_own_tx(self) -> bool:
+        """True if any configured broker opted into this node's own transmissions.
+
+        Lets the packet path skip building a tx record entirely in the default
+        ``publish_tx: off`` case.
+        """
+        with self._lock:
+            return any(conn.publish_tx != "off" for conn in self.connections)
+
     def publish_raw_data(self, raw_hex: str, subtopic="raw", retain=False):
         pkt = {"type": "raw", "data": raw_hex, "bytes": len(raw_hex) // 2}
         return self.publish_packet(pkt, subtopic, retain)
@@ -1004,12 +1066,22 @@ class MeshCoreToMqttPusher:
 
         packet_type = payload.get("type")
 
+        # Self-reported transmissions are opt-in per broker (see publish_tx).
+        is_own_tx = payload.get("direction") == "tx"
+        own_tx_type = _coerce_packet_type(payload.get("packet_type"))
+
         results = []
         with self._lock:
             for conn in self.connections:
                 if conn.enabled and conn.is_connected():
                     if packet_type in conn.disallowed_types:
                         _trace(f"Skipped publishing packet type 0x{packet_type:02X} (disallowed)")
+                        continue
+                    if is_own_tx and not conn.allows_tx_packet(own_tx_type):
+                        _trace(
+                            f"Skipped own-TX publish to {conn.broker['name']} "
+                            f"(publish_tx={conn.publish_tx})"
+                        )
                         continue
                     result = conn.publish(subtopic, message, retain=retain, qos=qos)
                     results.append((conn.broker["name"], result))

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -347,6 +347,27 @@ class StorageCollector:
             else:
                 logger.debug("Skipped mqtt publish: packet missing raw_packet data")
 
+            # Publish this node's own transmission of the packet as a separate
+            # ``direction: "tx"`` record. The radio is half-duplex, so nothing we
+            # receive can ever contain our own path hash -- without this, relays
+            # performed by this node are invisible to MQTT aggregators unless a
+            # second observer happens to be in range. Opt-in per broker via
+            # ``publish_tx``; brokers that did not opt in drop it in the handler.
+            if (
+                packet_record.get("transmitted")
+                and packet_record.get("raw_packet_tx")
+                and self.mqtt_handler.wants_own_tx()
+            ):
+                tx_packet = PacketRecord.from_packet_record(
+                    packet_record,
+                    origin=node_name,
+                    origin_id=self.mqtt_handler.public_key,
+                    direction="tx",
+                )
+                if tx_packet:
+                    self.mqtt_handler.publish_packet(tx_packet.to_dict())
+                    logger.debug(f"Published own TX of type 0x{packet_type:02X} to mqtt")
+
         except Exception as e:
             logger.error(f"Failed to publish packet to mqtt: {e}", exc_info=True)
 

--- a/repeater/data_acquisition/storage_utils.py
+++ b/repeater/data_acquisition/storage_utils.py
@@ -33,7 +33,7 @@ class PacketRecord:
 
     @classmethod
     def from_packet_record(
-        cls, packet_record: dict, origin: str, origin_id: str
+        cls, packet_record: dict, origin: str, origin_id: str, direction: str = "rx"
     ) -> Optional["PacketRecord"]:
         """
         Create PacketRecord from internal packet_record format.
@@ -48,11 +48,19 @@ class PacketRecord:
             packet_record: Internal packet record dictionary
             origin: Node name
             origin_id: Public key of the node
+            direction: ``"rx"`` serializes the packet as received. ``"tx"``
+                serializes this node's own transmission of it, using
+                ``raw_packet_tx`` (the forwarded bytes, which carry this node's
+                path hash). A half-duplex radio never receives its own
+                transmission, so the ``tx`` variant is the only way this node's
+                hash can appear in what it publishes.
 
         Returns:
-            PacketRecord instance or None if raw_packet is missing
+            PacketRecord instance or None if the required raw bytes are missing
         """
-        if "raw_packet" not in packet_record or not packet_record["raw_packet"]:
+        raw_key = "raw_packet_tx" if direction == "tx" else "raw_packet"
+        raw_packet = packet_record.get(raw_key)
+        if not raw_packet:
             return None
 
         # Extract timestamp and format date/time
@@ -70,16 +78,18 @@ class PacketRecord:
             origin_id=origin_id,
             timestamp=dt.isoformat(),
             type="PACKET",
-            direction="rx",
+            direction=direction,
             time=dt.strftime("%H:%M:%S"),
             date=dt.strftime("%-d/%-m/%Y"),
-            len=str(len(packet_record["raw_packet"]) // 2),
+            len=str(len(raw_packet) // 2),
             packet_type=str(packet_record.get("type", 0)),
             route=route,
             payload_len=str(packet_record.get("payload_length", 0)),
-            raw=packet_record["raw_packet"],
-            SNR=str(packet_record.get("snr", 0)),
-            RSSI=str(packet_record.get("rssi", 0)),
+            raw=raw_packet,
+            # A node cannot measure the signal of its own transmission, so the
+            # receive-side SNR/RSSI would be misleading on a tx record.
+            SNR="0" if direction == "tx" else str(packet_record.get("snr", 0)),
+            RSSI="0" if direction == "tx" else str(packet_record.get("rssi", 0)),
             score=str(int(packet_record.get("score", 0) * 1000)),
             duration=str(int(round(airtime_ms))),
             hash=packet_record.get("packet_hash", ""),

--- a/repeater/engine.py
+++ b/repeater/engine.py
@@ -364,6 +364,7 @@ class RepeaterHandler(BaseHandler):
             else self.process_packet(processed_packet, snr, packet_hash=pkt_hash_full)
         )
         forwarded_path_hashes = None
+        forwarded_raw = None
 
         # For local transmissions, create a direct transmission result (if local TX allowed)
         if local_transmission and allow_local_tx:
@@ -382,6 +383,16 @@ class RepeaterHandler(BaseHandler):
 
             # Capture the forwarded path (after modification)
             forwarded_path_hashes = fwd_pkt.get_path_hashes_hex()
+
+            # Capture the exact bytes we put on the air. These differ from
+            # ``raw_packet`` (as received) because the forwarded packet carries
+            # this node's own path hash. A half-duplex radio never hears its own
+            # transmission, so this is the only record of it that exists.
+            try:
+                forwarded_raw = fwd_pkt.write_to().hex() if hasattr(fwd_pkt, "write_to") else None
+            except Exception as e:
+                logger.debug(f"Could not serialize forwarded packet: {e}")
+                forwarded_raw = None
 
             # MeshCore queues multi-ack redundancy copies ahead of the primary
             # ACK at the same scheduled time, so create their TX tasks first.
@@ -573,6 +584,7 @@ class RepeaterHandler(BaseHandler):
             drop_reason=drop_reason,
             is_duplicate=is_dupe,
             forwarded_path=forwarded_path_hashes,
+            forwarded_raw=forwarded_raw,
             tx_delay_ms=tx_delay_ms,
             rx_radio_id=rx_radio_id,
             tx_radio_id=tx_radio_id,
@@ -823,6 +835,7 @@ class RepeaterHandler(BaseHandler):
         drop_reason: Optional[str] = None,
         is_duplicate: bool = False,
         forwarded_path=None,
+        forwarded_raw: Optional[str] = None,
         tx_delay_ms: float = 0.0,
         rx_radio_id: Optional[str] = None,
         tx_radio_id: Optional[str] = None,
@@ -897,6 +910,9 @@ class RepeaterHandler(BaseHandler):
             "upstream_hash": upstream_hash,
             "upstream_hash_size": upstream_hash_size,
             "raw_packet": packet.write_to().hex() if hasattr(packet, "write_to") else None,
+            # Bytes actually transmitted (includes our own path hash); None when
+            # this packet was not forwarded.
+            "raw_packet_tx": forwarded_raw,
             "lbt_attempts": lbt_attempts,
             "lbt_backoff_delays_ms": lbt_backoff_delays_ms,
             "lbt_channel_busy": lbt_channel_busy,

--- a/tests/test_mqtt_publish_own_tx.py
+++ b/tests/test_mqtt_publish_own_tx.py
@@ -259,6 +259,30 @@ def test_yaml_bare_on_enables_own_tx_end_to_end():
     assert [p["direction"] for p in _payloads(captured)] == ["rx", "tx"]
 
 
+def test_declined_tx_does_not_look_like_a_connectivity_failure(caplog):
+    """A tx record every broker declines must not warn about broker connections.
+
+    Regression: the skip used to `continue` without recording a result, leaving
+    ``results`` empty and emitting "No active broker connections" -- which sends
+    operators chasing a connectivity problem that does not exist.
+    """
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config(publish_tx="off")
+    )
+    conn = pusher.connections[0]
+    _attach_capturing_client(conn)
+
+    tx = PacketRecord.from_packet_record(
+        _packet_record(), origin="n", origin_id=PUBLIC_KEY_HEX.upper(), direction="tx"
+    )
+    with caplog.at_level("WARNING", logger="MQTTHandler"):
+        results = pusher.publish_packet(tx.to_dict())
+
+    assert results, "a deliberate skip must still be reported as a result"
+    assert results[0][1] == "Skipped: publish_tx"
+    assert "No active broker connections" not in caplog.text
+
+
 def test_invalid_publish_tx_falls_back_to_off():
     """A typo must fail closed, never start uplinking unexpectedly."""
     pusher = MeshCoreToMqttPusher(

--- a/tests/test_mqtt_publish_own_tx.py
+++ b/tests/test_mqtt_publish_own_tx.py
@@ -1,0 +1,275 @@
+"""Tests for publishing this node's own transmissions to MQTT.
+
+A half-duplex radio never receives its own transmission, so a packet this node
+relays can never appear in what it publishes: the received bytes carry the
+sender's path, not ours. Without an explicit tx record, a repeater's relays are
+invisible to MQTT aggregators unless a second observer is in radio range.
+
+These tests lock the opt-in contract:
+  * ``publish_tx: off`` (default) changes nothing.
+  * ``publish_tx: on`` emits a ``direction: "tx"`` record carrying the
+    *forwarded* bytes (which include this node's path hash).
+  * ``publish_tx: advert`` narrows that to this node's own adverts.
+
+paho-mqtt's network layer is mocked, so no broker is required.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from repeater.data_acquisition.mqtt_handler import MeshCoreToMqttPusher
+from repeater.data_acquisition.storage_utils import PacketRecord
+
+PUBLIC_KEY_HEX = "AB" * 32
+ADVERT_TYPE = 4
+REQ_TYPE = 0
+
+# Received bytes carry the upstream path only; the forwarded copy appends our hash.
+RAW_RX = "0141" + "be50" + "deadbeef"
+RAW_TX = "0142" + "be506742" + "deadbeef"
+
+
+class _FakeIdentity:
+    """Minimal LocalIdentity stand-in for constructor wiring."""
+
+    def __init__(self, public_key_hex: str):
+        self._pk = bytes.fromhex(public_key_hex)
+
+    def get_public_key(self) -> bytes:
+        return self._pk
+
+
+def _make_config(publish_tx=None) -> dict:
+    """Minimal config with a single letsmesh broker, optionally opted into tx."""
+    broker = {
+        "name": "test-broker",
+        "enabled": True,
+        "host": "broker.example",
+        "port": 1883,
+        "transport": "tcp",
+        "format": "letsmesh",
+        "use_jwt_auth": False,
+        "tls": {"enabled": False, "insecure": False},
+    }
+    if publish_tx is not None:
+        broker["publish_tx"] = publish_tx
+
+    return {
+        "repeater": {"node_name": "test-node"},
+        "radio": {
+            "spreading_factor": 8,
+            "bandwidth": 62500,
+            "coding_rate": 8,
+            "preamble_length": 17,
+            "frequency": 869618000,
+            "tx_power": 14,
+        },
+        "duty_cycle": {"max_airtime_per_minute": 3600},
+        "mqtt_brokers": {
+            "iata_code": "LAX",
+            "status_interval": 0,
+            "owner": "",
+            "email": "",
+            "brokers": [broker],
+        },
+    }
+
+
+def _attach_capturing_client(conn) -> list:
+    """Replace ``conn.client`` with a Mock and return the capture list."""
+    captured: list = []
+
+    def _fake_publish(topic, payload, retain=False, qos=0):
+        captured.append({"topic": topic, "payload": payload, "retain": retain, "qos": qos})
+        return None
+
+    conn._running = True
+    conn.client = MagicMock()
+    conn.client.publish = _fake_publish
+    return captured
+
+
+def _packet_record(packet_type: int = REQ_TYPE, transmitted: bool = True) -> dict:
+    return {
+        "timestamp": 1700000000.0,
+        "type": packet_type,
+        "route": 1,
+        "rssi": -90,
+        "snr": 7.5,
+        "score": 0.5,
+        "payload_length": 4,
+        "packet_hash": "DEADBEEF" + "00" * 4,
+        "raw_packet": RAW_RX,
+        "raw_packet_tx": RAW_TX if transmitted else None,
+        "transmitted": transmitted,
+        "airtime_ms": 100.0,
+    }
+
+
+def _publish_both(pusher, record: dict):
+    """Publish the rx record then the tx record, as storage_collector does."""
+    rx = PacketRecord.from_packet_record(
+        record, origin="test-node", origin_id=PUBLIC_KEY_HEX.upper()
+    )
+    pusher.publish_packet(rx.to_dict())
+
+    tx = PacketRecord.from_packet_record(
+        record, origin="test-node", origin_id=PUBLIC_KEY_HEX.upper(), direction="tx"
+    )
+    if tx is not None:
+        pusher.publish_packet(tx.to_dict())
+
+
+def _payloads(captured) -> list:
+    return [json.loads(c["payload"]) for c in captured]
+
+
+# --------------------------------------------------------------------
+# Serializer
+# --------------------------------------------------------------------
+def test_tx_record_uses_forwarded_bytes_and_drops_receive_signal():
+    """A tx record must carry the forwarded bytes, not the received ones."""
+    record = PacketRecord.from_packet_record(
+        _packet_record(), origin="n", origin_id=PUBLIC_KEY_HEX.upper(), direction="tx"
+    ).to_dict()
+
+    assert record["direction"] == "tx"
+    assert record["raw"] == RAW_TX, "tx record must carry the bytes we transmitted"
+    assert record["raw"] != RAW_RX
+    assert record["len"] == str(len(RAW_TX) // 2)
+    # A node cannot measure its own signal; reporting the receive-side values
+    # here would attribute another node's link quality to our transmission.
+    assert record["SNR"] == "0"
+    assert record["RSSI"] == "0"
+
+
+def test_rx_record_is_unchanged_by_the_new_parameter():
+    """The default path must serialize exactly as before."""
+    record = PacketRecord.from_packet_record(
+        _packet_record(), origin="n", origin_id=PUBLIC_KEY_HEX.upper()
+    ).to_dict()
+
+    assert record["direction"] == "rx"
+    assert record["raw"] == RAW_RX
+    assert record["RSSI"] == "-90"
+    assert record["SNR"] == "7.5"
+
+
+def test_tx_record_is_none_when_packet_was_not_forwarded():
+    """Nothing to report when the packet never went on the air."""
+    assert (
+        PacketRecord.from_packet_record(
+            _packet_record(transmitted=False),
+            origin="n",
+            origin_id=PUBLIC_KEY_HEX.upper(),
+            direction="tx",
+        )
+        is None
+    )
+
+
+# --------------------------------------------------------------------
+# Per-broker opt-in
+# --------------------------------------------------------------------
+def test_default_is_off_and_suppresses_own_tx():
+    """Absent config, behaviour is identical to before this feature."""
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config()
+    )
+    assert pusher.connections[0].publish_tx == "off"
+    assert pusher.wants_own_tx() is False
+
+    captured = _attach_capturing_client(pusher.connections[0])
+    _publish_both(pusher, _packet_record())
+
+    payloads = _payloads(captured)
+    assert len(payloads) == 1, "only the rx record may be published by default"
+    assert payloads[0]["direction"] == "rx"
+
+
+def test_publish_tx_on_emits_the_tx_record():
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config(publish_tx="on")
+    )
+    assert pusher.wants_own_tx() is True
+
+    captured = _attach_capturing_client(pusher.connections[0])
+    _publish_both(pusher, _packet_record())
+
+    payloads = _payloads(captured)
+    assert [p["direction"] for p in payloads] == ["rx", "tx"]
+    assert payloads[1]["raw"] == RAW_TX
+    assert payloads[1]["origin_id"] == PUBLIC_KEY_HEX.upper()
+    assert captured[1]["topic"] == f"meshcore/LAX/{PUBLIC_KEY_HEX.upper()}/packets"
+
+
+@pytest.mark.parametrize(
+    "packet_type,expect_tx",
+    [(ADVERT_TYPE, True), (REQ_TYPE, False)],
+)
+def test_publish_tx_advert_only_emits_adverts(packet_type, expect_tx):
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config(publish_tx="advert")
+    )
+    captured = _attach_capturing_client(pusher.connections[0])
+    _publish_both(pusher, _packet_record(packet_type=packet_type))
+
+    directions = [p["direction"] for p in _payloads(captured)]
+    assert directions == (["rx", "tx"] if expect_tx else ["rx"])
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # YAML 1.1 resolves bare on/off to booleans before we ever see them.
+        (True, "on"),
+        (False, "off"),
+        ("on", "on"),
+        ("off", "off"),
+        ("true", "on"),
+        ("false", "off"),
+        ("advert", "advert"),
+        (None, "off"),
+    ],
+)
+def test_publish_tx_accepts_yaml_boolean_and_string_spellings(raw, expected):
+    """``publish_tx: on`` in YAML arrives as True, not "on" -- both must work."""
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config(publish_tx=raw)
+    )
+    assert pusher.connections[0].publish_tx == expected
+
+
+def test_yaml_bare_on_enables_own_tx_end_to_end():
+    """Regression: a config written as `publish_tx: on` must actually uplink."""
+    import yaml
+
+    broker_yaml = yaml.safe_load("publish_tx: on")
+    assert broker_yaml["publish_tx"] is True, "precondition: YAML gives us a bool"
+
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX),
+        config=_make_config(publish_tx=broker_yaml["publish_tx"]),
+    )
+    captured = _attach_capturing_client(pusher.connections[0])
+    _publish_both(pusher, _packet_record())
+
+    assert [p["direction"] for p in _payloads(captured)] == ["rx", "tx"]
+
+
+def test_invalid_publish_tx_falls_back_to_off():
+    """A typo must fail closed, never start uplinking unexpectedly."""
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config(publish_tx="yes-please")
+    )
+    assert pusher.connections[0].publish_tx == "off"
+    assert pusher.wants_own_tx() is False
+
+
+def test_publish_tx_value_is_case_and_whitespace_tolerant():
+    pusher = MeshCoreToMqttPusher(
+        local_identity=_FakeIdentity(PUBLIC_KEY_HEX), config=_make_config(publish_tx="  ON  ")
+    )
+    assert pusher.connections[0].publish_tx == "on"


### PR DESCRIPTION
Closes #423

## Problem

A half-duplex radio never receives its own transmission, so a packet this node relays can never appear in what it publishes: the received bytes carry the upstream path, not ours. As a result a repeater's relays are invisible to MQTT aggregators (CoreScope, MeshMapper, LetsMesh) unless a second observer node happens to be in radio range.

The data already exists internally, since the forwarded packet carries our own path hash. It was simply never published.

Observed on a live node: CoreScope reported `relay_count_1h = 0` all day while the openHop dashboard showed hundreds of forwards. Bringing a separate observer ~55 m away back online moved it 0 to 5 within minutes.

## Change

Adds a per-broker `publish_tx`, mirroring the semantics of MeshCore's existing `set mqtt.tx`:

| value | behaviour |
| --- | --- |
| `off` | never publish own transmissions (default; behaviour unchanged) |
| `advert` | publish only this node's own adverts |
| `on` | publish every packet this node transmits, including relays |

Own-TX records are emitted as a separate `direction: "tx"` message, leaving the existing rx wire contract untouched. The payload carries the exact bytes put on the air, captured from the forwarded packet via `fwd_pkt.write_to()` rather than reconstructed, so the path hash is guaranteed to match what neighbours actually heard.

SNR/RSSI are reported as `0` on tx records: a node cannot measure the signal of its own transmission, and passing the receive-side values through would attribute another node's link quality to ours.

## Design notes

The default is `off`, and the packet path short-circuits via `wants_own_tx()` before building a tx record, so installs that do not opt in are unaffected and pay no per-packet cost.

Worth flagging: **YAML 1.1 resolves bare `on`/`off` to booleans**, so a config written the natural way (`publish_tx: on`) reaches the handler as `True`, not the string `"on"`. Values are normalized to accept the boolean forms, the quoted strings, and `true`/`false`. Anything unrecognized fails closed to `off` with a warning, so a typo can never silently start uplinking.

`raw_packet_tx` is added to the packet record dict. `store_packet` uses explicit columns with `.get()`, so no schema change or migration is required.

| file | change |
| --- | --- |
| `repeater/engine.py` | capture the transmitted bytes into `raw_packet_tx` |
| `repeater/data_acquisition/storage_utils.py` | `from_packet_record(..., direction=...)` |
| `repeater/data_acquisition/mqtt_handler.py` | normalize/validate `publish_tx`, per-broker gate, `wants_own_tx()` |
| `repeater/data_acquisition/storage_collector.py` | emit the tx record when transmitted |
| `config.yaml.example` | document the option |

## Testing

`tests/test_mqtt_publish_own_tx.py` adds 18 tests covering the serializer (forwarded bytes used, receive signal dropped, `None` when not forwarded), the default-off path, `on`, `advert` filtering, invalid-value fallback, case/whitespace tolerance, and the YAML boolean spellings end to end.

Full suite: 1023 passed, no regressions (1005 before this change). `ruff check` and `ruff format --check` are clean repo-wide on 0.15.14, the version pinned in `.pre-commit-config.yaml`. `scripts/check_openapi_contract.py` passes.

paho-mqtt's network layer is mocked throughout, so no broker is required.

The one path not covered by the mocked tests is the `engine.py` capture against real hardware. I will report back once this has run on a live repeater.
