### PR TITLE
ci: strengthen pull request validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [
     {name = "Rightup", email = "rightup@openhop.dev"},
 ]
-description = "PyMC Repeater Daemon"
+description = "openHop Repeater Daemon"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- formats `room_server.py` so the existing pre-commit gate passes
- updates the supported Python floor from 3.9 to 3.10 in package metadata and Ruff configuration
- runs the full test suite on Python 3.10 in addition to the Python 3.12 pre-commit job
- enables strict HTTP-method validation for the OpenAPI contract
- validates GitHub Actions workflows with actionlint
- checks shell scripts with ShellCheck at error severity
- builds and installs a clean wheel, then verifies packaged runtime files and console entry points
- adds path-filtered Dockerfile and Compose validation without building or pushing an image

## Container check scope

The container job runs only when Docker-related files change. It uses Buildx `--check`, Compose configuration validation, and Hadolint at error severity. The complete local container validation took 2 seconds; the existing full multi-architecture image build remains limited to `dev` and `main` publication.

## Verification

- full pre-commit suite on Python 3.12
- full pytest suite on Python 3.10
- strict OpenAPI contract check
- actionlint
- ShellCheck
- Buildx Dockerfile check
- Docker Compose configuration check
- Hadolint
- clean wheel build, installation, package-data check, and `openhop-repeater --help`
