### PR TITLE
fix(sqlite): stop creating the upstream index before its columns exist

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -217,10 +217,11 @@ class SQLiteHandler:
                 )
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_packets_type ON packets(type)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_packets_hash ON packets(packet_hash)")
-                conn.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_packets_upstream_time "
-                    "ON packets(upstream_hash, upstream_hash_size, timestamp)"
-                )
+                # idx_packets_upstream_time is intentionally NOT created here.
+                # It spans upstream_hash / upstream_hash_size, which only exist
+                # on a pre-existing database once the add_upstream_hash_to_packets
+                # migration has added them -- and migrations run after this. The
+                # migration creates the index itself; see _run_migrations.
                 conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_packets_transmitted ON packets(transmitted)"
                 )

--- a/tests/test_sqlite_upgrade_existing_db.py
+++ b/tests/test_sqlite_upgrade_existing_db.py
@@ -1,0 +1,182 @@
+"""Regression test: opening a pre-existing database must not break packet recording.
+
+`SQLiteHandler.__init__` runs `_init_database()` and then `_run_migrations()`.
+`_init_database` used to create `idx_packets_upstream_time`, an index spanning
+`upstream_hash` / `upstream_hash_size` -- columns that only exist on an older
+database once `add_upstream_hash_to_packets` has added them, which happens in
+the migration step afterwards.
+
+On a fresh install this passed, because the `CREATE TABLE` includes the columns.
+On any existing install it raised ``no such column: upstream_hash``, which
+`_init_database` caught and logged. Every statement after the failing index was
+therefore skipped, and the daemon came up looking completely healthy -- service
+active, radio initialised, companions serving, HTTP up -- while recording zero
+packets and doing no RX/TX.
+
+These tests build a database with the *old* packets schema and assert that a
+handler opens it, ends up with both columns and the index, and can insert.
+"""
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler  # noqa: E402
+
+# The packets columns that predate migration 13. Enough of the real schema for
+# the handler to treat this as an existing database rather than a fresh one.
+_OLD_PACKETS_SCHEMA = """
+CREATE TABLE packets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp REAL,
+    type INTEGER,
+    route INTEGER,
+    length INTEGER,
+    rssi REAL,
+    snr REAL,
+    score REAL,
+    transmitted INTEGER,
+    is_duplicate INTEGER,
+    drop_reason TEXT,
+    src_hash TEXT,
+    dst_hash TEXT,
+    path_hash TEXT,
+    header TEXT,
+    transport_codes TEXT,
+    payload TEXT,
+    payload_length INTEGER,
+    packet_hash TEXT
+)
+"""
+
+
+def _make_legacy_db(path):
+    con = sqlite3.connect(path)
+    con.execute(_OLD_PACKETS_SCHEMA)
+    con.execute(
+        "INSERT INTO packets (timestamp, type, length) VALUES (?, ?, ?)", (1.0, 1, 10)
+    )
+    con.commit()
+    con.close()
+
+
+def _columns(path, table="packets"):
+    con = sqlite3.connect(path)
+    try:
+        return {row[1] for row in con.execute("PRAGMA table_info(%s)" % table)}
+    finally:
+        con.close()
+
+
+def _indexes(path):
+    con = sqlite3.connect(path)
+    try:
+        return {
+            r[0]
+            for r in con.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        }
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def legacy_db():
+    """A storage dir holding a repeater.db with the pre-migration-13 schema."""
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "repeater.db")
+    _make_legacy_db(path)
+    yield d, path
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def test_opens_database_missing_upstream_hash_columns(legacy_db):
+    """The upgrade path must complete, not half-apply."""
+    d, path = legacy_db
+    assert "upstream_hash" not in _columns(path), "fixture is not a legacy db"
+
+    SQLiteHandler(Path(d))
+
+    cols = _columns(path)
+    assert "upstream_hash" in cols
+    assert "upstream_hash_size" in cols
+
+
+def test_upstream_index_exists_after_upgrade(legacy_db):
+    """The index must still be created -- by the migration that owns the columns."""
+    d, path = legacy_db
+    SQLiteHandler(Path(d))
+    assert "idx_packets_upstream_time" in _indexes(path)
+
+
+def _tables(path):
+    con = sqlite3.connect(path)
+    try:
+        return {
+            r[0]
+            for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    finally:
+        con.close()
+
+
+def test_schema_init_runs_to_completion(legacy_db):
+    """The actual damage: `_init_database` aborting part-way.
+
+    This is what the caught exception hid. `idx_packets_upstream_time` was
+    created roughly two thirds of the way through `_init_database`; when it
+    raised, every statement after it was skipped and the error was swallowed.
+    The daemon then ran with a partially-created schema.
+
+    `room_messages` and `room_client_sync` are created *after* that point, so
+    their presence is a direct proof that schema init completed. Asserting on
+    the upstream columns alone is not enough -- the migration adds those
+    afterwards either way, which is exactly why this bug self-heals on the
+    second start and is so easy to misread as harmless.
+    """
+    d, path = legacy_db
+    SQLiteHandler(Path(d))
+
+    tables = _tables(path)
+    for late in ("room_messages", "room_client_sync"):
+        assert late in tables, (
+            "%s is missing: _init_database did not run to completion on an "
+            "existing database" % late
+        )
+
+
+def test_recording_works_after_upgrade(legacy_db):
+    """A packet insert must still land once the upgrade has run."""
+    d, path = legacy_db
+    SQLiteHandler(Path(d))
+
+    con = sqlite3.connect(path)
+    try:
+        before = con.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+        con.execute(
+            "INSERT INTO packets (timestamp, type, length, upstream_hash) "
+            "VALUES (?, ?, ?, ?)",
+            (2.0, 1, 12, "ABCD"),
+        )
+        con.commit()
+        after = con.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+    finally:
+        con.close()
+    assert after == before + 1
+
+
+def test_fresh_database_also_gets_column_and_index():
+    """The fresh-install path must be unaffected by moving the index."""
+    d = tempfile.mkdtemp()
+    try:
+        SQLiteHandler(Path(d))
+        path = os.path.join(d, "repeater.db")
+        assert {"upstream_hash", "upstream_hash_size"} <= _columns(path)
+        assert "idx_packets_upstream_time" in _indexes(path)
+    finally:
+        shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
Fixes #428.

Upgrading an existing database to current `dev` leaves the daemon running but recording nothing, while every obvious health check passes. Full analysis in the issue.

**The change.** `idx_packets_upstream_time` spans `upstream_hash` / `upstream_hash_size`, which on an older database only exist once `add_upstream_hash_to_packets` has added them — and migrations run *after* `_init_database`. So on any pre-migration-13 database, `_init_database` raised `no such column: upstream_hash` part-way through, caught it, and returned; every statement after the failing index was skipped, including the `room_messages` and `room_client_sync` tables.

The migration already creates this index itself, immediately after adding the columns it depends on, so the copy in `_init_database` was redundant as well as too early. Removing it leaves the index to the migration that owns those columns. All three paths still end up with it: a fresh database gets the columns from `CREATE TABLE` and the index when the migration runs; an un-migrated database gets both from the migration; an already-migrated one kept it from the earlier run.

**Scope.** This PR is deliberately just that one change. An earlier revision also made `_init_database` raise rather than swallow; per review that is dropped, since turning a recoverable upgrade issue into a startup failure is the wrong default for constrained or headless installs. Discussion of a non-fatal but *legible* alternative is in the review thread.

**Tests.** `tests/test_sqlite_upgrade_existing_db.py` builds a database with the pre-migration-13 `packets` schema and asserts `_init_database` runs to completion, keyed on `room_messages` / `room_client_sync` — tables created after the old failure point.

Worth noting for review: asserting on the upstream columns alone is *not* sufficient. Those end up present either way, because the migration adds them after the failed init. That is also why the bug self-heals on a second start and is easy to dismiss as transient. My first version of this test passed against unfixed `dev` for exactly that reason.

Verified on a Raspberry Pi 4 (Python 3.13.5) against a real ~13 MB production database:

- new tests: `1 failed, 4 passed` on stock `dev`; `5 passed` with this commit
- the discriminating assertion is `test_schema_init_runs_to_completion`, which depends only on the index move
- rest of the suite unchanged versus stock `dev` — the same 3 pre-existing failures either way (`test_send_advert_paths`, `test_asyncio_executor_threads_are_not_reported_as_blockers`, `test_load_config_normalizes_in_memory_without_rewriting_file`)
- the live repeater has been running the patched build since, recording normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
