### PR TITLE
test: stop the suite killing itself part-way through

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared test guards.
+
+`RepeaterDaemon._shutdown` arms an exit watchdog: a `threading.Timer` that calls
+`os._exit(0)` once `SHUTDOWN_EXIT_GRACE_S` has elapsed. That is correct in
+production -- it guarantees SIGTERM is honoured -- but a test that reaches
+`_shutdown` without patching it leaves a live timer behind. When it fires, five
+seconds later, it takes the whole pytest process down **with status 0**, part
+way through an unrelated test.
+
+The damage is that it looks like success: pytest exits 0 with no summary line
+and a truncated progress bar, so CI reports green on a run that never finished
+and any failure after that point is invisible. The test blamed in the output is
+whichever happened to be running when the timer fired, so it moves between runs
+and does not point at the cause.
+
+The autouse fixture below fails the *responsible* test instead, at the moment it
+leaks the timer.
+"""
+import threading
+
+import pytest
+
+_WATCHDOG_NAME = "shutdown-watchdog"
+
+
+def _live_watchdogs():
+    return [t for t in threading.enumerate() if t.name == _WATCHDOG_NAME and t.is_alive()]
+
+
+@pytest.fixture(autouse=True)
+def no_leaked_exit_watchdog():
+    """Fail any test that leaves a live shutdown-exit watchdog behind.
+
+    Patch it out when the code under test reaches `_shutdown`:
+
+        with patch.object(daemon, "_arm_exit_watchdog"):
+            await daemon.run()
+
+    or, when the watchdog itself is what you are testing, keep the grace short
+    and assert on a patched `repeater.main.os._exit` before the test returns.
+    """
+    yield
+
+    leaked = _live_watchdogs()
+    for timer in leaked:
+        timer.cancel()
+
+    if leaked:
+        pytest.fail(
+            "test left %d live '%s' timer(s) running. Each one calls os._exit(0) "
+            "when it fires and will kill the pytest process mid-run, with exit "
+            "status 0 and no summary. Patch _arm_exit_watchdog for this test."
+            % (len(leaked), _WATCHDOG_NAME),
+            pytrace=False,
+        )

--- a/tests/test_main_py_more.py
+++ b/tests/test_main_py_more.py
@@ -76,6 +76,12 @@ async def test_run_starts_http_and_handles_dispatcher_cancelled_gracefully():
         patch("asyncio.get_running_loop", return_value=fake_loop_for_signals),
         patch("repeater.main.HTTPStatsServer", return_value=fake_http_instance),
         patch("os.path.exists", return_value=False),
+        # run()'s finally reaches _shutdown(), which arms the real exit
+        # watchdog: a threading.Timer that calls os._exit(0) after
+        # SHUTDOWN_EXIT_GRACE_S (5 s). It would fire long after this test
+        # returns and take the whole pytest process down. Same guard the
+        # shutdown tests in test_main_py_coverage.py already use.
+        patch.object(daemon, "_arm_exit_watchdog"),
     ):
         await daemon.run()
 


### PR DESCRIPTION
Fixes #430.

`_shutdown` arms a `threading.Timer` that calls `os._exit(0)` after 5 s. `test_run_starts_http_and_handles_dispatcher_cancelled_gracefully` awaits `daemon.run()`, whose `finally` reaches `_shutdown()`, so it armed a real watchdog and returned — and five seconds later the timer took pytest down.

Because `os._exit(0)` exits with status **zero**, the run looked like a success: no summary line, truncated progress bar, `$?` of 0. CI would read that as green on a run that never finished, and every test after the kill point was invisible. The 3 genuine pre-existing failures on `dev` only became visible once the process survived to the end.

**Two changes:**

1. Patch `_arm_exit_watchdog` for that test — the same guard the shutdown tests in `test_main_py_coverage.py` already use.

2. Add `tests/conftest.py` with an autouse fixture that fails any test leaving a live `shutdown-watchdog` timer, and cancels it.

The second is the one I would argue for keeping. The bug misattributes itself: the test blamed is whichever is running five seconds later, so it moves between runs — I saw `test_route_login_server_companion_only_skips_login_helper` and then `test_route_login_server_hash_collision_offers_to_both`, neither related to shutdown. Tracking it down needed wrapping `_arm_exit_watchdog` to log the arming test. The fixture makes the next occurrence blame the right test immediately, with a message saying what to do.

I verified the guard actually works: with the one-line fix reverted, the run goes from a silent process-kill to

```
ERROR at teardown of test_run_starts_http_and_handles_dispatcher_cancelled_gracefully
test left 1 live 'shutdown-watchdog' timer(s) running...
```

`test_exit_watchdog_is_a_daemon_timer_that_forces_exit` is unaffected — it sets a 0.05 s grace and asserts on a patched `os._exit` before returning, so it leaves nothing behind.

**Result** (Raspberry Pi 4, Python 3.13.5, `dev` at `efc5616`):

- before: no summary, truncated at `[ 77%]`, exit 0
- after: `3 failed, 1580 passed, 20 subtests passed`, exit 1

Those 3 are pre-existing on `dev` and untouched by this PR: `test_send_advert_paths`, `test_asyncio_executor_threads_are_not_reported_as_blockers`, `test_load_config_normalizes_in_memory_without_rewriting_file`. Happy to open a separate issue for them if useful.
