### PR TITLE
fix(companion): make bulk contact import match stored advert types

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -3831,6 +3831,30 @@ class SQLiteHandler:
             logger.error(f"Failed to upsert companion contact: {e}")
             return False
 
+    # ``adverts.contact_type`` stores the *display* name written via
+    # handler_helpers.discovery.NODE_TYPE_NAMES ("Chat Node", "Repeater",
+    # "Room Server", "Sensor"). The import API speaks MeshCore's names
+    # ("companion", "repeater", "room_server", "sensor"). Normalising the stored
+    # form once, here, keeps the SQL filter and the adv_type assignment from
+    # drifting apart -- they were previously derived independently, so the
+    # filter compared display names against API names and matched nothing.
+    _ADVERT_TYPE_BY_STORED = {
+        "chat_node": 1,
+        "chat": 1,
+        "client": 1,
+        "companion": 1,
+        "repeater": 2,
+        "room_server": 3,
+        "room": 3,
+        "sensor": 4,
+    }
+    _ADVERT_TYPE_BY_API = {"companion": 1, "repeater": 2, "room_server": 3, "sensor": 4}
+
+    @staticmethod
+    def _normalise_advert_type(raw) -> str:
+        """Fold a stored contact_type to its lookup key ("Chat Node" -> "chat_node")."""
+        return (raw or "").lower().replace(" ", "_").strip()
+
     def companion_import_repeater_contacts(
         self,
         companion_hash: str,
@@ -3844,7 +3868,6 @@ class SQLiteHandler:
         imported first. Optional hours filters to adverts seen within the last N hours;
         optional limit caps how many contacts are imported.
         """
-        type_map = {"companion": 1, "repeater": 2, "room_server": 3, "sensor": 4}
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
@@ -3854,9 +3877,24 @@ class SQLiteHandler:
                 )
                 params: list = []
                 if contact_types:
-                    placeholders = ",".join("?" * len(contact_types))
-                    query += f" AND contact_type IN ({placeholders})"
-                    params.extend(contact_types)
+                    wanted = {
+                        self._ADVERT_TYPE_BY_API[t]
+                        for t in contact_types
+                        if t in self._ADVERT_TYPE_BY_API
+                    }
+                    stored = sorted(
+                        key
+                        for key, adv in self._ADVERT_TYPE_BY_STORED.items()
+                        if adv in wanted
+                    )
+                    if not stored:
+                        return 0
+                    placeholders = ",".join("?" * len(stored))
+                    query += (
+                        " AND LOWER(REPLACE(TRIM(contact_type), ' ', '_')) "
+                        f"IN ({placeholders})"
+                    )
+                    params.extend(stored)
                 if hours is not None:
                     cutoff = time.time() - (hours * 3600)
                     query += " AND last_seen >= ?"
@@ -3871,9 +3909,9 @@ class SQLiteHandler:
             now = time.time()
             contact_rows = []
             for row in rows:
-                raw_type = row["contact_type"] or ""
-                normalized_type = raw_type.lower().replace(" ", "_").strip()
-                adv_type = type_map.get(normalized_type, 0)
+                adv_type = self._ADVERT_TYPE_BY_STORED.get(
+                    self._normalise_advert_type(row["contact_type"]), 0
+                )
                 contact_rows.append(
                     (
                         companion_hash,

--- a/tests/test_companion_import_repeater_contacts.py
+++ b/tests/test_companion_import_repeater_contacts.py
@@ -1,0 +1,129 @@
+"""Regression tests for bulk 'import repeater contacts'.
+
+``adverts.contact_type`` stores the *display* name written through
+``handler_helpers.discovery.NODE_TYPE_NAMES`` -- "Chat Node", "Repeater",
+"Room Server", "Sensor". The import API accepts MeshCore's names -- "companion",
+"repeater", "room_server", "sensor" (validated in
+``companion_endpoints.import_repeater_contacts``).
+
+``companion_import_repeater_contacts`` compared the two directly:
+
+    query += f" AND contact_type IN ({placeholders})"   # API names
+                                                        # vs stored display names
+
+so every filtered import matched zero rows and reported success having written
+nothing. Separately the adv_type lookup normalised "Chat Node" to "chat_node",
+which was absent from its map, so chat contacts imported as adv_type 0 rather
+than 1 even on an unfiltered import.
+
+Both derived the mapping independently; they now share one table.
+"""
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler  # noqa: E402
+
+# Exactly the forms the repeater writes.
+SEEDS = [
+    ("aa" * 32, "RepeaterOne", "Repeater", 2),
+    ("bb" * 32, "ChatOne", "Chat Node", 1),
+    ("cc" * 32, "RoomOne", "Room Server", 3),
+    ("dd" * 32, "SensorOne", "Sensor", 4),
+]
+
+
+@pytest.fixture
+def handler():
+    d = tempfile.mkdtemp()
+    h = SQLiteHandler(Path(d))
+    con = sqlite3.connect(os.path.join(d, "repeater.db"))
+    now = time.time()
+    for pk, name, ctype, _ in SEEDS:
+        con.execute(
+            "INSERT INTO adverts"
+            " (timestamp, pubkey, node_name, is_repeater, contact_type, latitude,"
+            "  longitude, first_seen, last_seen, advert_count, is_new_neighbor, zero_hop)"
+            " VALUES (?, ?, ?, ?, ?, 0, 0, ?, ?, 1, 0, 0)",
+            (now, pk, name, 1 if ctype == "Repeater" else 0, ctype, now, now),
+        )
+    con.commit()
+    con.close()
+    yield h, d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _imported(d, companion="0x01"):
+    con = sqlite3.connect(os.path.join(d, "repeater.db"))
+    try:
+        return {
+            (r[0].hex() if isinstance(r[0], (bytes, bytearray)) else r[0]): r[1]
+            for r in con.execute(
+                "select pubkey, adv_type from companion_contacts where companion_hash=?",
+                (companion,),
+            )
+        }
+    finally:
+        con.close()
+
+
+def test_unfiltered_import_takes_everything(handler):
+    h, d = handler
+    n = h.companion_import_repeater_contacts("0x01")
+    assert n == len(SEEDS)
+    assert len(_imported(d)) == len(SEEDS)
+
+
+@pytest.mark.parametrize(
+    "api_name,expected_pubkey",
+    [
+        ("repeater", "aa" * 32),
+        ("companion", "bb" * 32),
+        ("room_server", "cc" * 32),
+        ("sensor", "dd" * 32),
+    ],
+)
+def test_each_contact_type_filter_matches_its_stored_display_name(
+    handler, api_name, expected_pubkey
+):
+    """The bug: every one of these returned 0."""
+    h, d = handler
+    n = h.companion_import_repeater_contacts("0x01", contact_types=[api_name])
+    assert n == 1, "contact_types=[%r] imported nothing" % api_name
+    assert set(_imported(d)) == {expected_pubkey}
+
+
+def test_all_four_filters_together(handler):
+    h, d = handler
+    n = h.companion_import_repeater_contacts(
+        "0x01", contact_types=["companion", "repeater", "room_server", "sensor"]
+    )
+    assert n == len(SEEDS)
+
+
+def test_adv_type_is_correct_for_every_stored_name(handler):
+    """'Chat Node' must import as adv_type 1, not 0."""
+    h, d = handler
+    h.companion_import_repeater_contacts("0x01")
+    got = _imported(d)
+    for pk, _name, stored, expected in SEEDS:
+        assert got[pk] == expected, "%r imported as adv_type %s, expected %s" % (
+            stored,
+            got[pk],
+            expected,
+        )
+    assert 0 not in got.values(), "some contact imported with adv_type 0 (unset)"
+
+
+def test_unknown_contact_type_still_imports_nothing(handler):
+    """A type the API would reject must not silently widen the query."""
+    h, _ = handler
+    assert h.companion_import_repeater_contacts("0x01", contact_types=["nonsense"]) == 0


### PR DESCRIPTION
Fixes #435.

"Import repeater contacts" imported nothing whenever a contact-type filter was supplied, and reported success. Full measurements in the issue.

**Cause.** `adverts.contact_type` holds the display name written via `handler_helpers.discovery.NODE_TYPE_NAMES` (`"Chat Node"`, `"Repeater"`, `"Room Server"`, `"Sensor"`); the API accepts MeshCore's names (`"companion"`, `"repeater"`, `"room_server"`, `"sensor"`). `companion_import_repeater_contacts` compared them directly, so no permitted value ever matched — on a live repeater with 285 adverts, each of the four selected 0 rows, as did all four together.

The same mismatch caused a second, quieter defect: the `adv_type` lookup normalised the stored name but resolved it against the API-name table, where `"chat_node"` is absent, so chat contacts imported as `adv_type = 0` instead of `1` even on an unfiltered import. That one is silently wrong rather than empty and needs a manual `UPDATE` to repair.

**Change.** Both sites derived the mapping independently, which is how they drifted apart. They now share one `_ADVERT_TYPE_BY_STORED` table keyed on the normalised stored form:

- the filter reverse-maps the requested API names onto stored keys and compares `LOWER(REPLACE(TRIM(contact_type), ' ', '_'))`, so filtering and limiting stay in SQL rather than moving into Python
- `adv_type` is read from the same table
- an unrecognised type returns 0 rather than silently widening the query

Aliases (`chat`, `client`, `room`) are included so a future display-name change doesn't reintroduce this silently.

**Tests.** `tests/test_companion_import_repeater_contacts.py` seeds the adverts table with the exact stored display names and covers each filter individually, all four together, the unfiltered path, `adv_type` for every type, and the unknown-type case.

Verified on a Raspberry Pi 4 (Python 3.13.5) against `dev` at `efc5616`:

- new tests: **6 failed, 2 passed** on stock `dev`; **8 passed** with this change
- full suite: `3 failed, 1588 passed` — the same 3 pre-existing failures as stock `dev` (`test_send_advert_paths`, `test_asyncio_executor_threads_are_not_reported_as_blockers`, `test_load_config_normalizes_in_memory_without_rewriting_file`), untouched here

Note for reviewers: the full suite only reaches its summary with #431 applied, or the watchdog otherwise neutralised — without it the run is killed part-way and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
