### PR TITLE
Fix frontend switching cache and plugin card scaling

### DIFF
--- a/repeater/web/html/assets/plugin-ui-overrides.css
+++ b/repeater/web/html/assets/plugin-ui-overrides.css
@@ -1,0 +1,28 @@
+/*
+ * Integration-layer correction for the generated Plugins catalogue cards.
+ * The upstream UI source is not present in this repository, so keep this
+ * override isolated instead of modifying content-hashed bundle output.
+ */
+
+/* The card grid stretches peers to the tallest card. Let copy absorb that
+ * extra room while keeping catalogue artwork within a bounded media region. */
+div:has(> div > img[alt$=" artwork"]) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+div:has(> img[alt$=" artwork"]) {
+  height: clamp(6.5rem, 12vw, 8rem) !important;
+  flex: 0 0 auto;
+}
+
+img[alt$=" artwork"] {
+  object-fit: contain !important;
+  padding: 0.75rem;
+}
+
+div:has(> img[alt$=" artwork"]) + div {
+  min-width: 0;
+  flex: 1 1 auto;
+}

--- a/repeater/web/html/index.html
+++ b/repeater/web/html/index.html
@@ -23,6 +23,7 @@
     <link rel="modulepreload" crossorigin href="/assets/websocket-Bfv9t1xI.js">
     <link rel="modulepreload" crossorigin href="/assets/constants-Hl8RMxy-.js">
     <link rel="stylesheet" crossorigin href="/assets/index-BiFEUy8v.css">
+    <link rel="stylesheet" href="/assets/plugin-ui-overrides.css">
   </head>
   <body>
     <div id="app"></div>

--- a/repeater/web/http_server.py
+++ b/repeater/web/http_server.py
@@ -281,6 +281,14 @@ class StatsApp:
         current = self._resolve_html_dir()
         return previous != current
 
+    @staticmethod
+    def _set_html_response_headers() -> None:
+        """Prevent a browser from reusing another frontend's root document."""
+        cherrypy.response.headers["Content-Type"] = "text/html; charset=utf-8"
+        cherrypy.response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+        cherrypy.response.headers["Pragma"] = "no-cache"
+        cherrypy.response.headers["Expires"] = "0"
+
     def _serve_static_file(self, root_dir: str, relative_parts: tuple[str, ...]):
         if not relative_parts:
             raise cherrypy.NotFound()
@@ -346,12 +354,14 @@ class StatsApp:
                 cherrypy.response.headers["Content-Type"] = (
                     guessed_type or "application/octet-stream"
                 )
+                if target.suffix.lower() == ".html":
+                    self._set_html_response_headers()
                 return target.read_bytes()
 
             # SPA fallback to entry HTML for client-side routes
             entry_target = safe_join(doc_root, entry_name)
             if entry_target.is_file():
-                cherrypy.response.headers["Content-Type"] = "text/html; charset=utf-8"
+                self._set_html_response_headers()
                 return entry_target.read_bytes()
             raise cherrypy.NotFound()
         except cherrypy.HTTPError:
@@ -373,6 +383,7 @@ class StatsApp:
         index_path = os.path.join(self.html_dir, "index.html")
         try:
             with open(index_path, "r", encoding="utf-8") as f:
+                self._set_html_response_headers()
                 return f.read()
         except FileNotFoundError:
             raise cherrypy.HTTPError(404, "Application not found. Please build the frontend first.")

--- a/tests/test_bundled_plugin_ui_layout.py
+++ b/tests/test_bundled_plugin_ui_layout.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+HTML_ROOT = Path(__file__).resolve().parents[1] / "repeater" / "web" / "html"
+
+
+def test_plugin_catalogue_artwork_uses_bounded_media_region():
+    css = (HTML_ROOT / "assets" / "plugin-ui-overrides.css").read_text(encoding="utf-8")
+
+    assert 'img[alt$=" artwork"]' in css
+    assert "object-fit: contain" in css
+    assert "height: clamp(" in css
+    assert "flex: 1 1 auto" in css
+
+
+def test_plugin_layout_override_loads_after_generated_stylesheet():
+    index = (HTML_ROOT / "index.html").read_text(encoding="utf-8")
+
+    generated = index.index("/assets/index-")
+    override = index.index("/assets/plugin-ui-overrides.css")
+    assert generated < override

--- a/tests/test_http_server_unit.py
+++ b/tests/test_http_server_unit.py
@@ -117,7 +117,10 @@ def test_stats_app_index_and_default_routing(monkeypatch, tmp_path):
     app = hs.StatsApp(config={"web": {"web_path": str(tmp_path)}})
 
     monkeypatch.setattr(cherrypy, "request", SimpleNamespace(method="GET"), raising=False)
+    monkeypatch.setattr(cherrypy, "response", SimpleNamespace(headers={}), raising=False)
     assert app.index() == "<html>ok</html>"
+    assert cherrypy.response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate"
+    assert cherrypy.response.headers["Pragma"] == "no-cache"
 
     monkeypatch.setattr(cherrypy, "request", SimpleNamespace(method="OPTIONS"), raising=False)
     assert app.default("anything") == ""

--- a/tests/test_plugin_api_endpoints.py
+++ b/tests/test_plugin_api_endpoints.py
@@ -117,6 +117,7 @@ def test_ui_serving_index_assets_spa_and_disabled(tmp_path):
 
     index = app._serve_plugin_ui(plugin_id, ())
     assert b"ok" in index
+    assert cherrypy.response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate"
 
     # Paths are relative to the entry directory (ui/), matching Vite base './'
     asset = app._serve_plugin_ui(plugin_id, ("assets", "app.js"))
@@ -125,6 +126,7 @@ def test_ui_serving_index_assets_spa_and_disabled(tmp_path):
     # SPA fallback
     spa = app._serve_plugin_ui(plugin_id, ("dashboard", "settings"))
     assert b"ok" in spa
+    assert cherrypy.response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate"
 
     # Path traversal rejected
     with pytest.raises(cherrypy.HTTPError):


### PR DESCRIPTION
## Summary

- Prevent browsers from reusing stale frontend HTML after switching between the built-in UI, Console, and application UI plugins at the same root URL.
- Keep hashed static assets cacheable while sending no-store/no-cache headers for root, direct plugin, and SPA-fallback HTML responses.
- Bound plugin catalogue artwork and let the text region absorb card-height changes across browser zoom and responsive layouts.
- Keep the generated bundle untouched by applying the layout correction through an isolated stylesheet loaded after generated CSS.

## Verification

- `1646 passed, 20 subtests passed`.
- Focused HTTP, plugin route, and layout coverage passed.
- Firefox first-load and refresh checks matched in both dark and light preferences with no browser errors.
- Exact built wheel was installed on a native Repeater and verified through the live HTTP path.
- Root HTML returns the new cache policy; the override stylesheet returns as CSS and is loaded by the browser.
