### PR TITLE
feat(api): summarise neighbor link history in buckets

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -2331,7 +2331,9 @@ class SQLiteHandler:
         path_hash_size: int,
         hours: int = 24,
         limit: int = 1000,
+        bucket_seconds: Optional[int] = None,
     ) -> list:
+        """Observations of one peer, oldest first; ``bucket_seconds`` summarises them instead."""
         try:
             normalized_hash = str(peer_hash or "").strip().upper()
             if not normalized_hash:
@@ -2344,6 +2346,11 @@ class SQLiteHandler:
 
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
+                if bucket_seconds is not None:
+                    return self._bucket_neighbor_link_history(
+                        conn, normalized_hash, path_hash_size, cutoff, int(bucket_seconds), limit
+                    )
+
                 rows = conn.execute(
                     """
                     SELECT
@@ -2397,6 +2404,53 @@ class SQLiteHandler:
         except Exception as e:
             logger.error(f"Failed to get neighbor link history: {e}")
             return []
+
+    @staticmethod
+    def _bucket_neighbor_link_history(
+        conn,
+        peer_hash: str,
+        path_hash_size: int,
+        cutoff: float,
+        bucket_seconds: int,
+        limit: int,
+    ) -> list:
+        bucket_seconds = max(1, bucket_seconds)
+        rows = conn.execute(
+            """
+            SELECT
+                CAST(timestamp / ? AS INTEGER) * ? AS bucket_ts,
+                COUNT(*) AS n,
+                SUM(is_duplicate) AS dup,
+                MAX(timestamp) AS last_ts,
+                AVG(score) AS score,
+                AVG(rssi) AS rssi,
+                AVG(snr) AS snr
+            FROM packets INDEXED BY idx_packets_upstream_time
+            WHERE upstream_hash = ?
+              AND upstream_hash_size = ?
+              AND timestamp >= ?
+            GROUP BY bucket_ts
+            ORDER BY bucket_ts DESC
+            LIMIT ?
+            """,
+            (bucket_seconds, bucket_seconds, peer_hash, path_hash_size, cutoff, limit),
+        ).fetchall()
+
+        def mean(value):
+            return None if value is None else round(value, 3)
+
+        return [
+            {
+                "timestamp": int(row["bucket_ts"]),
+                "last_ts": row["last_ts"],
+                "n": int(row["n"]),
+                "dup": int(row["dup"]),
+                "score": mean(row["score"]),
+                "rssi": mean(row["rssi"]),
+                "snr": mean(row["snr"]),
+            }
+            for row in reversed(rows)
+        ]
 
     def get_packet_type_stats(self, hours: int = 24) -> dict:
         try:

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -502,12 +502,14 @@ class StorageCollector:
         path_hash_size: int,
         hours: int = 24,
         limit: int = 1000,
+        bucket_seconds: Optional[int] = None,
     ) -> list:
         return self.sqlite_handler.get_neighbor_link_history(
             peer_hash=peer_hash,
             path_hash_size=path_hash_size,
             hours=hours,
             limit=limit,
+            bucket_seconds=bucket_seconds,
         )
 
     def get_rrd_data(

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -3854,7 +3854,9 @@ class APIEndpoints:
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def neighbor_link_history(self, peer_hash=None, path_hash_size=None, hours=24, limit=1000):
+    def neighbor_link_history(
+        self, peer_hash=None, path_hash_size=None, hours=24, limit=1000, bucket_seconds=None
+    ):
         try:
             if not peer_hash:
                 return self._error("peer_hash parameter required")
@@ -3864,23 +3866,28 @@ class APIEndpoints:
             size = int(path_hash_size)
             window_hours = int(hours)
             row_limit = int(limit)
+            bucket_s = max(60, int(bucket_seconds)) if bucket_seconds is not None else None
 
             rows = self._get_storage().get_neighbor_link_history(
                 peer_hash=str(peer_hash),
                 path_hash_size=size,
                 hours=window_hours,
                 limit=row_limit,
+                bucket_seconds=bucket_s,
             )
-            return self._success(
-                {
-                    "peer_hash": str(peer_hash).upper(),
-                    "path_hash_size": size,
-                    "hours": window_hours,
-                    "limit": row_limit,
-                    "rows": rows,
-                    "count": len(rows),
-                }
-            )
+            data = {
+                "peer_hash": str(peer_hash).upper(),
+                "path_hash_size": size,
+                "hours": window_hours,
+                "limit": row_limit,
+                "count": len(rows),
+            }
+            if bucket_s is not None:
+                data["bucket_seconds"] = bucket_s
+                data["buckets"] = rows
+            else:
+                data["rows"] = rows
+            return self._success(data)
         except ValueError as e:
             return self._error(f"Invalid parameter format: {e}")
         except Exception as e:

--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -1071,7 +1071,14 @@ paths:
             default: 1000
             minimum: 1
             maximum: 5000
-          description: Maximum rows to return.
+          description: Maximum rows (or buckets) to return.
+        - name: bucket_seconds
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 60
+          description: Bucket width in seconds; the answer carries `buckets` instead of `rows`.
       responses:
         '200':
           description: Neighbour link history
@@ -5271,10 +5278,28 @@ components:
           type: integer
         rows:
           type: array
+          description: Observations, oldest first; absent when `bucket_seconds` was requested.
           items:
             $ref: '#/components/schemas/NeighborLinkHistoryRow'
+        bucket_seconds: {type: integer, description: Bucket width in seconds; only when requested}
+        buckets:
+          type: array
+          description: One summary per non-empty bucket, oldest first; only when `bucket_seconds` was requested.
+          items:
+            $ref: '#/components/schemas/NeighborLinkHistoryBucket'
         count:
           type: integer
+
+    NeighborLinkHistoryBucket:
+      type: object
+      properties:
+        timestamp: {type: integer, description: Bucket start (Unix timestamp)}
+        last_ts: {type: number, description: The bucket's last observation}
+        n: {type: integer, description: Observations in the bucket}
+        dup: {type: integer, description: Observations flagged as duplicates}
+        score: {type: number, nullable: true, description: Mean score}
+        rssi: {type: number, nullable: true, description: Mean RSSI}
+        snr: {type: number, nullable: true, description: Mean SNR}
 
     NeighborLinkHistoryResponse:
       type: object

--- a/tests/test_api_endpoints_core_coverage.py
+++ b/tests/test_api_endpoints_core_coverage.py
@@ -1025,7 +1025,23 @@ def test_neighbor_link_history_endpoint_filters_by_hash_and_size(cherrypy_ctx):
         path_hash_size=2,
         hours=12,
         limit=50,
+        bucket_seconds=None,
     )
+
+
+def test_neighbor_link_history_endpoint_buckets(cherrypy_ctx):
+    del cherrypy_ctx
+    api = _make_api()
+    buckets = [{"timestamp": 600}, {"timestamp": 1200}]
+    storage = SimpleNamespace(get_neighbor_link_history=MagicMock(return_value=buckets))
+    _attach_storage(api, storage)
+
+    data = api.neighbor_link_history(peer_hash="ab", path_hash_size="1", bucket_seconds="30")[
+        "data"
+    ]
+    assert "rows" not in data
+    assert (data["bucket_seconds"], data["buckets"], data["count"]) == (60, buckets, 2)
+    assert storage.get_neighbor_link_history.call_args.kwargs["bucket_seconds"] == 60
 
 
 def test_recent_packets_and_bulk_packets(cherrypy_ctx):

--- a/tests/test_sqlite_handler_easy.py
+++ b/tests/test_sqlite_handler_easy.py
@@ -308,6 +308,45 @@ def test_neighbor_link_history_uses_packets_table_and_filters_hash_and_size(tmp_
     assert rows[1]["is_duplicate"] is True
 
 
+def _store_link_observation(h, ts, score, rssi, snr, duplicate=False, hash_="AA"):
+    h.store_packet(
+        {
+            "timestamp": ts,
+            "type": 4,
+            "route": 1,
+            "length": 10,
+            "rssi": rssi,
+            "snr": snr,
+            "score": score,
+            "is_duplicate": duplicate,
+            "packet_hash": f"pkt-{ts}",
+            "upstream_hash": hash_,
+            "upstream_hash_size": 1,
+            "original_path": [hash_],
+        }
+    )
+
+
+def test_neighbor_link_history_buckets_summarise_the_rows(tmp_path):
+    h = _make_handler(tmp_path)
+    t0 = 1_700_000_400.0  # a 600 s boundary
+    _store_link_observation(h, t0 + 5, 0.2, -100, -2.0)
+    _store_link_observation(h, t0 + 300, 0.6, -80, 4.0, duplicate=True)
+    _store_link_observation(h, t0 + 599, 0.4, -90, 1.0)
+    _store_link_observation(h, t0 + 1300, 0.9, -70, 8.0)
+    _store_link_observation(h, t0 + 10, 0.0, -120, -9.0, hash_="BB")
+
+    def history(**kwargs):
+        return h.get_neighbor_link_history(peer_hash="AA", path_hash_size=1, hours=50000, **kwargs)
+
+    first, second = history(bucket_seconds=600)
+    assert (first["timestamp"], first["last_ts"], first["n"], first["dup"]) == (t0, t0 + 599, 3, 1)
+    assert (first["score"], first["rssi"], first["snr"]) == (0.4, -90.0, 1.0)
+    assert (second["timestamp"], second["n"], second["score"]) == (t0 + 1200, 1, 0.9)
+    assert [b["timestamp"] for b in history(bucket_seconds=600, limit=1)] == [t0 + 1200]
+    assert len(history()) == 4
+
+
 def test_recent_packet_queries_include_ids_and_preserve_duplicate_hash_rows(tmp_path):
     h = _make_handler(tmp_path)
 

--- a/tests/test_storage_collector_neighbor_link_history.py
+++ b/tests/test_storage_collector_neighbor_link_history.py
@@ -1,0 +1,12 @@
+from unittest.mock import Mock
+
+from repeater.data_acquisition.storage_collector import StorageCollector
+
+
+def test_forwards_bucket_seconds():
+    collector = StorageCollector.__new__(StorageCollector)
+    collector.sqlite_handler = Mock()
+    collector.get_neighbor_link_history(peer_hash="2A", path_hash_size=1, bucket_seconds=600)
+    collector.sqlite_handler.get_neighbor_link_history.assert_called_once_with(
+        peer_hash="2A", path_hash_size=1, hours=24, limit=1000, bucket_seconds=600
+    )


### PR DESCRIPTION
`GET /api/neighbor_link_history` returns raw observations, at most `limit` (default 1000) of the window. A week of a busy link is far more than that, and a chart doesn't need every row anyway.

Adds one optional param, `bucket_seconds` (min 60, as on `lbt_diagnostics`). With it the answer carries `buckets` instead of `rows`: one per non-empty bucket, oldest first, with `timestamp`, `last_ts`, `n`, `dup`, and the mean `score`, `rssi`, `snr`. Same `GROUP BY` shape as `get_policy_event_counts`, same index (`idx_packets_upstream_time`). A week at 600 s is at most 1,008 entries whatever the traffic.

Without the param the response is unchanged. `openapi.yaml` updated; one test per layer.

`pre-commit` is red at baseline on `dev` (formatter drift, IPC timeout test); untouched here.
