### PR TITLE
feat(api): opt-in raw frames on the packet list endpoints

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -2078,26 +2078,29 @@ class SQLiteHandler:
             logger.error(f"Failed to get SQLite metrics data: {e}", exc_info=True)
             raise
 
-    def get_recent_packets(self, limit: int = 100) -> list:
+    _PACKET_LIST_SELECT_PLAIN = (
+        "SELECT id, "
+        "timestamp, type, route, length, rssi, snr, score, "
+        "transmitted, is_duplicate, drop_reason, src_hash, dst_hash, path_hash, "
+        "upstream_hash, upstream_hash_size, "
+        "transport_codes, payload, payload_length, "
+        "tx_delay_ms, rx_radio_id, tx_radio_id, "
+        "packet_hash, original_path, forwarded_path, "
+        "lbt_attempts, lbt_channel_busy "
+        "FROM packets"
+    )
+    _PACKET_LIST_SELECT_RAW = _PACKET_LIST_SELECT_PLAIN.replace(
+        " FROM packets", ", raw_packet FROM packets"
+    )
+
+    def get_recent_packets(self, limit: int = 100, include_raw: bool = False) -> list:
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
 
                 packets = conn.execute(
-                    """
-                    SELECT
-                        id,
-                        timestamp, type, route, length, rssi, snr, score,
-                        transmitted, is_duplicate, drop_reason, src_hash, dst_hash, path_hash,
-                        upstream_hash, upstream_hash_size,
-                        transport_codes, payload, payload_length,
-                        tx_delay_ms, rx_radio_id, tx_radio_id,
-                        packet_hash, original_path, forwarded_path,
-                        lbt_attempts, lbt_channel_busy
-                    FROM packets
-                    ORDER BY timestamp DESC
-                    LIMIT ?
-                """,
+                    f"{self._PACKET_LIST_SELECT_RAW if include_raw else self._PACKET_LIST_SELECT_PLAIN}"
+                    " ORDER BY timestamp DESC LIMIT ?",
                     (limit,),
                 ).fetchall()
 
@@ -2115,6 +2118,7 @@ class SQLiteHandler:
         end_timestamp: Optional[float] = None,
         limit: int = 1000,
         offset: int = 0,
+        include_raw: bool = False,
     ) -> list:
         try:
             with self._connect() as conn:
@@ -2139,18 +2143,9 @@ class SQLiteHandler:
                     where_clauses.append("timestamp <= ?")
                     params.append(end_timestamp)
 
-                base_query = """
-                    SELECT
-                        id,
-                        timestamp, type, route, length, rssi, snr, score,
-                        transmitted, is_duplicate, drop_reason, src_hash, dst_hash, path_hash,
-                        upstream_hash, upstream_hash_size,
-                        transport_codes, payload, payload_length,
-                        tx_delay_ms, rx_radio_id, tx_radio_id,
-                        packet_hash, original_path, forwarded_path,
-                        lbt_attempts, lbt_channel_busy
-                    FROM packets
-                """
+                base_query = (
+                    self._PACKET_LIST_SELECT_RAW if include_raw else self._PACKET_LIST_SELECT_PLAIN
+                )
 
                 if where_clauses:
                     query = f"{base_query} WHERE {' AND '.join(where_clauses)}"

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -451,8 +451,8 @@ class StorageCollector:
     def get_packet_stats(self, hours: int = 24) -> dict:
         return self.sqlite_handler.get_packet_stats(hours)
 
-    def get_recent_packets(self, limit: int = 100) -> list:
-        return self.sqlite_handler.get_recent_packets(limit)
+    def get_recent_packets(self, limit: int = 100, include_raw: bool = False) -> list:
+        return self.sqlite_handler.get_recent_packets(limit, include_raw=include_raw)
 
     def get_filtered_packets(
         self,
@@ -462,9 +462,16 @@ class StorageCollector:
         end_timestamp: Optional[float] = None,
         limit: int = 1000,
         offset: int = 0,
+        include_raw: bool = False,
     ) -> list:
         return self.sqlite_handler.get_filtered_packets(
-            packet_type, route, start_timestamp, end_timestamp, limit, offset
+            packet_type,
+            route,
+            start_timestamp,
+            end_timestamp,
+            limit,
+            offset,
+            include_raw=include_raw,
         )
 
     def get_airtime_data(

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -3896,10 +3896,12 @@ class APIEndpoints:
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def recent_packets(self, limit=100):
+    def recent_packets(self, limit=100, include_raw=None):
         try:
             limit = int(limit)
-            packets = self._get_storage().get_recent_packets(limit=limit)
+            packets = self._get_storage().get_recent_packets(
+                limit=limit, include_raw=str(include_raw).lower() in ("true", "1", "yes")
+            )
             return self._success(packets, count=len(packets))
         except Exception as e:
             logger.error(f"Error getting recent packets: {e}")
@@ -3908,13 +3910,16 @@ class APIEndpoints:
     @cherrypy.expose
     @cherrypy.tools.gzip(compress_level=6)
     @cherrypy.tools.json_out()
-    def bulk_packets(self, limit=1000, offset=0, start_timestamp=None, end_timestamp=None):
+    def bulk_packets(
+        self, limit=1000, offset=0, start_timestamp=None, end_timestamp=None, include_raw=None
+    ):
         """
         Optimized bulk packet retrieval with gzip compression and DB-level pagination.
         """
         try:
-            # Enforce reasonable limits
-            limit = min(int(limit), 10000)
+            # Enforce reasonable limits; raw frames make a page several times heavier
+            include_raw = str(include_raw).lower() in ("true", "1", "yes")
+            limit = min(int(limit), 1000 if include_raw else 10000)
             offset = max(int(offset), 0)
 
             # Get packets from storage with TRUE DB-level pagination
@@ -3927,6 +3932,7 @@ class APIEndpoints:
                 end_timestamp=float(end_timestamp) if end_timestamp else None,
                 limit=limit,
                 offset=offset,
+                include_raw=include_raw,
             )
 
             response = {
@@ -3947,7 +3953,13 @@ class APIEndpoints:
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def filtered_packets(
-        self, start_timestamp=None, end_timestamp=None, limit=1000, type=None, route=None
+        self,
+        start_timestamp=None,
+        end_timestamp=None,
+        limit=1000,
+        type=None,
+        route=None,
+        include_raw=None,
     ):
         # Handle OPTIONS request for CORS preflight
         if cherrypy.request.method == "OPTIONS":
@@ -3968,6 +3980,7 @@ class APIEndpoints:
                 start_timestamp=start_ts,
                 end_timestamp=end_ts,
                 limit=limit_int,
+                include_raw=str(include_raw).lower() in ("true", "1", "yes"),
             )
             return self._success(
                 packets,

--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -874,6 +874,12 @@ paths:
             minimum: 1
             maximum: 1000
           description: Maximum number of packets to return
+        - name: include_raw
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Add each packet's raw frame (raw_packet, hex) to the rows
       responses:
         '200':
           description: Recent packets
@@ -995,6 +1001,12 @@ paths:
             type: integer
             default: 1000
           description: Maximum results
+        - name: include_raw
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Add each packet's raw frame (raw_packet, hex) to the rows
       responses:
         '200':
           description: Filtered packets
@@ -3707,6 +3719,12 @@ paths:
           in: query
           schema:
             type: number
+        - name: include_raw
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Add each packet's raw frame (raw_packet, hex) to the rows
       responses:
         '200':
           description: Bulk packet result

--- a/tests/test_api_endpoints_core_coverage.py
+++ b/tests/test_api_endpoints_core_coverage.py
@@ -1048,7 +1048,7 @@ def test_recent_packets_and_bulk_packets(cherrypy_ctx):
     assert bulk["limit"] == 10000
     assert bulk["compressed"] is True
 
-    storage.get_recent_packets.assert_called_once_with(limit=2)
+    storage.get_recent_packets.assert_called_once_with(limit=2, include_raw=False)
     storage.get_filtered_packets.assert_called_once_with(
         packet_type=None,
         route=None,
@@ -1056,7 +1056,28 @@ def test_recent_packets_and_bulk_packets(cherrypy_ctx):
         end_timestamp=3.5,
         limit=10000,
         offset=0,
+        include_raw=False,
     )
+
+
+def test_packet_lists_read_the_include_raw_flag(cherrypy_ctx):
+    del cherrypy_ctx
+    api = _make_api()
+    storage = SimpleNamespace(
+        get_recent_packets=MagicMock(return_value=[]),
+        get_filtered_packets=MagicMock(return_value=[]),
+    )
+    _attach_storage(api, storage)
+
+    api.recent_packets("5", include_raw="1")
+    assert api.bulk_packets(limit="5000", include_raw="true")["limit"] == 1000
+    api.filtered_packets(limit="5", include_raw="yes")
+
+    storage.get_recent_packets.assert_called_once_with(limit=5, include_raw=True)
+    assert [c.kwargs["include_raw"] for c in storage.get_filtered_packets.call_args_list] == [
+        True,
+        True,
+    ]
 
 
 def test_filtered_packets_options_and_success(cherrypy_ctx):
@@ -1093,6 +1114,7 @@ def test_filtered_packets_options_and_success(cherrypy_ctx):
         start_timestamp=10.0,
         end_timestamp=20.0,
         limit=5,
+        include_raw=False,
     )
 
 

--- a/tests/test_sqlite_handler_easy.py
+++ b/tests/test_sqlite_handler_easy.py
@@ -349,6 +349,27 @@ def test_recent_packet_queries_include_ids_and_preserve_duplicate_hash_rows(tmp_
     assert by_id["packet_hash"] == "same-hash"
 
 
+def test_packet_list_queries_add_raw_frame_only_on_request(tmp_path):
+    h = _make_handler(tmp_path)
+    h.store_packet(
+        {
+            "timestamp": 100.0,
+            "type": 2,
+            "route": 1,
+            "length": 12,
+            "transmitted": False,
+            "is_duplicate": False,
+            "packet_hash": "with-frame",
+            "raw_packet": "0901aa55",
+        }
+    )
+    assert "raw_packet" not in h.get_recent_packets(limit=10)[0]
+    assert "raw_packet" not in h.get_filtered_packets(limit=10)[0]
+    assert h.get_recent_packets(limit=10, include_raw=True)[0]["raw_packet"] == "0901aa55"
+    windowed = h.get_filtered_packets(start_timestamp=50.0, limit=10, include_raw=True)
+    assert windowed[0]["raw_packet"] == "0901aa55"
+
+
 def test_verify_api_token_last_used_throttle(tmp_path, monkeypatch):
     h = _make_handler(tmp_path)
     h._api_token_last_used_interval_sec = 300

--- a/tests/test_storage_collector_packet_lists.py
+++ b/tests/test_storage_collector_packet_lists.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from repeater.data_acquisition.storage_collector import StorageCollector
+
+
+def test_packet_list_wrappers_forward_include_raw():
+    collector = StorageCollector.__new__(StorageCollector)
+    collector.sqlite_handler = Mock()
+    collector.get_recent_packets(limit=25, include_raw=True)
+    collector.sqlite_handler.get_recent_packets.assert_called_once_with(25, include_raw=True)
+    collector.get_filtered_packets(limit=10, offset=5)
+    collector.sqlite_handler.get_filtered_packets.assert_called_once_with(
+        None, None, None, None, 10, 5, include_raw=False
+    )


### PR DESCRIPTION
Adds an opt-in `include_raw=1` to `GET /api/recent_packets` and `GET /api/bulk_packets`. With it each row carries `raw_packet` (hex); without it the answers are unchanged.

be56e91 dropped `raw_packet` from the list queries, which keeps pages small but leaves a client that decodes packets itself with nothing to decode from history (`packet_by_hash` is one packet at a time). The flag keeps the default lean and lets such a client ask.

Handler, `StorageCollector` passthrough and endpoints, with tests at each layer; `openapi.yaml` updated.

`ruff format` wants to reflow two unrelated lines already on `dev` in `sqlite_handler.py`; left as they are.
