### PR TITLE
fix(manage): pull checkout and reload upgrade script to avoid double installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,25 @@ sudo bash ./manage.sh upgrade
 
 The upgrade script will:
 
-- Pull the latest code from the main branch
+- Run `git pull --ff-only` in the checkout containing `manage.sh`, following the
+  current branch's configured upstream (it does not switch branches)
+- Re-execute the updated script if the pull changed `manage.sh`, so new upgrade
+  logic takes effect in the same invocation
 - Update application files
 - Upgrade Python dependencies if needed
 - Restart the service automatically
 - Preserve the existing configuration
+
+The pull happens before installation/configuration changes. Local tracked changes,
+a detached HEAD, a missing upstream, or a failed pull abort the upgrade without
+stashing, resetting, or merging your work. Resolve those Git conditions first.
+Untracked files are left alone; Git still refuses a pull that would overwrite them.
+
+A standalone copy of `manage.sh` outside a checkout cannot pull itself; its existing
+Git-package fallback uses `dev` (or `OPENHOP_UPGRADE_REF`). Run from a current clone
+to keep the management script and support files aligned with the installed package.
+Older scripts without this self-update step need one manual `git pull --ff-only`
+before running `sudo bash ./manage.sh upgrade` to pick up this behavior.
 
 ## Proxmox LXC Installation
 

--- a/manage.sh
+++ b/manage.sh
@@ -60,6 +60,55 @@ is_expected_repo_checkout() {
     return 1
 }
 
+# Refresh the checkout supplying both the package and its management logic.
+# Never pull the caller's cwd or silently merge/stash administrator changes.
+refresh_upgrade_checkout() {
+    local silent="${1:-true}"
+    local before after branch changes
+
+    if [ ! -e "$SCRIPT_DIR/.git" ]; then
+        echo "No Git checkout beside manage.sh; keeping standalone upgrade source."
+        return 0
+    fi
+    if ! command -v git >/dev/null 2>&1; then
+        error "Git is required to update the manage.sh checkout"
+        return 1
+    fi
+    branch="$(git -C "$SCRIPT_DIR" symbolic-ref --quiet --short HEAD)" || {
+        error "Checkout has detached HEAD; switch to the branch you want to upgrade first"
+        return 1
+    }
+    changes="$(git -C "$SCRIPT_DIR" status --porcelain --untracked-files=no)" || return 1
+    if [ -n "$changes" ]; then
+        error "Checkout has local changes; commit or stash them before upgrading"
+        return 1
+    fi
+    if ! git -C "$SCRIPT_DIR" rev-parse --verify '@{upstream}' >/dev/null 2>&1; then
+        error "Branch $branch has no upstream; configure its tracking branch before upgrading"
+        return 1
+    fi
+    before="$(git -C "$SCRIPT_DIR" hash-object "$SCRIPT_PATH")" || return 1
+    echo ">>> Pulling checkout branch $branch in $SCRIPT_DIR ..."
+    if ! git -C "$SCRIPT_DIR" pull --ff-only; then
+        error "Git pull failed; upgrade aborted before changing the installation"
+        return 1
+    fi
+    after="$(git -C "$SCRIPT_DIR" hash-object "$SCRIPT_PATH")" || return 1
+    echo "Checkout revision: $(git -C "$SCRIPT_DIR" rev-parse HEAD)"
+    if [ "$before" != "$after" ]; then
+        echo "manage.sh changed; restarting with the updated upgrade logic..."
+        # The new process acquires the lock normally. No installation changes
+        # have happened yet; aborting on a competing upgrade is safe.
+        exec 9>&-
+        if [[ "$silent" == "true" ]]; then
+            exec bash "$SCRIPT_PATH" upgrade --silent
+        else
+            exec bash "$SCRIPT_PATH" upgrade --interactive
+        fi
+    fi
+    return 0
+}
+
 determine_package_source() {
     local script_dir=$1
     local requested_ref=$2
@@ -1164,6 +1213,8 @@ upgrade_repeater() {
         error "Invalid upgrade ref: $requested_ref"
         return 1
     fi
+
+    refresh_upgrade_checkout "$silent" || return 1
 
     package_source="$(determine_package_source "$SCRIPT_DIR" "$requested_ref")"
     package_requirement="$(build_package_requirement "$package_source")"

--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -3884,16 +3884,13 @@ class SQLiteHandler:
                         if t in self._ADVERT_TYPE_BY_API
                     }
                     stored = sorted(
-                        key
-                        for key, adv in self._ADVERT_TYPE_BY_STORED.items()
-                        if adv in wanted
+                        key for key, adv in self._ADVERT_TYPE_BY_STORED.items() if adv in wanted
                     )
                     if not stored:
                         return 0
                     placeholders = ",".join("?" * len(stored))
                     query += (
-                        " AND LOWER(REPLACE(TRIM(contact_type), ' ', '_')) "
-                        f"IN ({placeholders})"
+                        f" AND LOWER(REPLACE(TRIM(contact_type), ' ', '_')) IN ({placeholders})"
                     )
                     params.extend(stored)
                 if hours is not None:

--- a/tests/test_companion_import_repeater_contacts.py
+++ b/tests/test_companion_import_repeater_contacts.py
@@ -18,6 +18,7 @@ than 1 even on an unfiltered import.
 
 Both derived the mapping independently; they now share one table.
 """
+
 import os
 import shutil
 import sqlite3

--- a/tests/test_manage_upgrade_checkout.py
+++ b/tests/test_manage_upgrade_checkout.py
@@ -1,0 +1,169 @@
+"""Exercise upgrade checkout preparation with real local Git repositories.
+
+Only the function-definition prefix is loaded: no apt, pip, systemd or live paths.
+"""
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "manage.sh").read_text()
+PREFIX = SOURCE.split("# Check if we're running in an interactive terminal")[0]
+# bash -c has no BASH_SOURCE; supply only path constants through positional $0.
+PREFIX = "\n".join(
+    'readonly SCRIPT_PATH="$0"'
+    if line.startswith("readonly SCRIPT_PATH=")
+    else 'readonly SCRIPT_DIR="$(dirname -- "$0")"'
+    if line.startswith("readonly SCRIPT_DIR=")
+    else line
+    for line in PREFIX.splitlines()
+)
+
+
+def git(path, *args):
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=dict(
+            os.environ,
+            GIT_AUTHOR_NAME="Test Fixture",
+            GIT_AUTHOR_EMAIL="fixture@example.invalid",
+            GIT_COMMITTER_NAME="Test Fixture",
+            GIT_COMMITTER_EMAIL="fixture@example.invalid",
+        ),
+    ).stdout.strip()
+
+
+@pytest.fixture
+def checkout(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    git(remote, "init", "-b", "dev")
+    (remote / "pyproject.toml").write_text("# old source\n")
+    # Safe replacement body makes re-execution observable without upgrading a host.
+    (remote / "manage.sh").write_text(PREFIX + '\nprintf "OLD:%s\\n" "$*"\n')
+    git(remote, "add", ".")
+    git(remote, "commit", "-m", "initial fixture")
+    local = tmp_path / "checkout"
+    git(tmp_path, "clone", str(remote), str(local))
+    return remote, local
+
+
+def run_refresh(local, cwd=None):
+    # Bash positional $0 supplies BASH_SOURCE for the real prefix constants.
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            PREFIX + '\nrefresh_upgrade_checkout true || exit $?\nprintf "CONTINUED\\n"\n',
+            str(local / "manage.sh"),
+        ],
+        cwd=cwd or local,
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_refresh_pulls_script_directory_not_callers_directory(checkout, tmp_path):
+    remote, local = checkout
+    (remote / "pyproject.toml").write_text("# new source\n")
+    git(remote, "commit", "-am", "update package")
+    result = run_refresh(local, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert (local / "pyproject.toml").read_text() == "# new source\n"
+    assert "CONTINUED" in result.stdout
+
+
+def test_updated_script_runs_in_same_invocation(checkout):
+    remote, local = checkout
+    (remote / "manage.sh").write_text('#!/bin/bash\nprintf "NEW:%s\\n" "$*"\n')
+    git(remote, "commit", "-am", "new installer logic")
+    result = run_refresh(local)
+    assert result.returncode == 0, result.stderr
+    assert "NEW:upgrade --silent" in result.stdout
+    assert "CONTINUED" not in result.stdout
+
+
+@pytest.mark.parametrize("problem", ["dirty", "detached", "diverged", "no-upstream", "offline"])
+def test_unsafe_or_failed_pull_aborts_before_upgrade(checkout, problem):
+    remote, local = checkout
+    if problem == "dirty":
+        (local / "pyproject.toml").write_text("# user changes\n")
+    elif problem == "detached":
+        git(local, "checkout", "--detach")
+    elif problem == "no-upstream":
+        git(local, "branch", "--unset-upstream")
+    elif problem == "offline":
+        git(local, "remote", "set-url", "origin", str(remote / "missing"))
+    else:
+        (local / "local.txt").write_text("local\n")
+        git(local, "add", ".")
+        git(local, "commit", "-m", "local divergence")
+        (remote / "remote.txt").write_text("remote\n")
+        git(remote, "add", ".")
+        git(remote, "commit", "-m", "remote divergence")
+    before = git(local, "rev-parse", "HEAD")
+    result = run_refresh(local)
+    assert result.returncode != 0
+    assert "CONTINUED" not in result.stdout
+    assert git(local, "rev-parse", "HEAD") == before
+    if problem == "dirty":
+        assert (local / "pyproject.toml").read_text() == "# user changes\n"
+
+
+def test_standalone_script_skips_pull(tmp_path):
+    result = run_refresh(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "CONTINUED" in result.stdout
+
+
+def test_linked_worktree_is_updated(checkout, tmp_path):
+    remote, local = checkout
+    linked = tmp_path / "linked"
+    git(local, "worktree", "add", "-b", "linked", str(linked), "origin/dev")
+    (remote / "pyproject.toml").write_text("# updated worktree\n")
+    git(remote, "commit", "-am", "advance")
+    result = run_refresh(linked)
+    assert result.returncode == 0, result.stderr
+    assert (linked / "pyproject.toml").read_text() == "# updated worktree\n"
+
+
+def test_refresh_precedes_package_selection_and_mutations():
+    upgrade = SOURCE.split("upgrade_repeater() {", 1)[1].split("# Radio Configuration function")[0]
+    refresh = upgrade.index('refresh_upgrade_checkout "$silent" || return 1')
+    assert refresh < upgrade.index('package_source="$(determine_package_source')
+    assert refresh < upgrade.index("migrate_legacy_paths")
+
+
+def test_reexec_releases_existing_lock(checkout, tmp_path):
+    remote, local = checkout
+    lock = tmp_path / "manage.lock"
+    (remote / "manage.sh").write_text(
+        "#!/bin/bash\nexec 9>"
+        + shlex.quote(str(lock))
+        + "\nflock -n 9 || exit 73\nprintf 'LOCKED\\n'\n"
+    )
+    git(remote, "commit", "-am", "updated manager acquires lock")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            PREFIX + '\nexec 9>"$1"\nflock -n 9\nrefresh_upgrade_checkout true\n',
+            str(local / "manage.sh"),
+            str(lock),
+        ],
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "LOCKED" in result.stdout


### PR DESCRIPTION
## Summary

This should address the reported need to run `manage.sh upgrade` twice when the checkout or management script is out of date. It also adds an explicit Git pull before upgrading.

Previously, an upgrade from a checkout installed the local source without pulling it, despite the README describing a pull. Updating the script on disk also needs an explicit re-execution to ensure the current invocation uses the new upgrade logic rather than already-loaded functions.

### Changes

- Run `git pull --ff-only` in the checkout containing `manage.sh`, following the current branch's configured upstream without switching branches.
- Pull before package-source selection and installation/configuration migration steps.
- If the pull changes `manage.sh`, re-execute the updated script during the same invocation so a second manual upgrade is not needed to run the new logic.
- Abort on tracked local changes, detached HEAD, missing upstream, or a failed pull; do not stash, reset, or merge user changes.
- Preserve the existing package-source fallback for standalone scripts outside a checkout.
- Correct the README and add regression coverage for Git checkout preparation and lock handling across re-execution.

### Scope and caveats

This is the proposed fix for the stale-checkout/old-script path behind the double-install reports, not a claim that every reported case has been reproduced. No affected-user logs were available. A separate legacy-path migration issue was identified during investigation and is not changed here.

Existing copies of `manage.sh` without this behavior need one manual `git pull --ff-only` to acquire the updated script first.

## Verification

- 11 new regression tests pass using real temporary Git repositories, covering pulls from a different working directory, same-invocation script re-execution, linked worktrees, failure paths, and lock reacquisition.
- Full suite: 1,803 tests passed, plus 20 subtests.
- Bash syntax, changed-test Ruff lint/format checks, and `git diff --check` pass.
- Native deployment exercised the actual `manage.sh upgrade` path: the pull ran before installation, the deployed script matched the committed file, service-user module discovery and `pip check` passed, and HTTP readiness remained healthy with no automatic restarts after the successful deployment.
- Live deployment used an already-current checkout; the changed-script re-execution path was verified by the Git regression tests.
