### PR TITLE
feat(api): keyset cursor on bulk_packets

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -2078,26 +2078,29 @@ class SQLiteHandler:
             logger.error(f"Failed to get SQLite metrics data: {e}", exc_info=True)
             raise
 
-    def get_recent_packets(self, limit: int = 100) -> list:
+    _PACKET_LIST_SELECT_PLAIN = (
+        "SELECT id, "
+        "timestamp, type, route, length, rssi, snr, score, "
+        "transmitted, is_duplicate, drop_reason, src_hash, dst_hash, path_hash, "
+        "upstream_hash, upstream_hash_size, "
+        "transport_codes, payload, payload_length, "
+        "tx_delay_ms, rx_radio_id, tx_radio_id, "
+        "packet_hash, original_path, forwarded_path, "
+        "lbt_attempts, lbt_channel_busy "
+        "FROM packets"
+    )
+    _PACKET_LIST_SELECT_RAW = _PACKET_LIST_SELECT_PLAIN.replace(
+        " FROM packets", ", raw_packet FROM packets"
+    )
+
+    def get_recent_packets(self, limit: int = 100, include_raw: bool = False) -> list:
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
 
                 packets = conn.execute(
-                    """
-                    SELECT
-                        id,
-                        timestamp, type, route, length, rssi, snr, score,
-                        transmitted, is_duplicate, drop_reason, src_hash, dst_hash, path_hash,
-                        upstream_hash, upstream_hash_size,
-                        transport_codes, payload, payload_length,
-                        tx_delay_ms, rx_radio_id, tx_radio_id,
-                        packet_hash, original_path, forwarded_path,
-                        lbt_attempts, lbt_channel_busy
-                    FROM packets
-                    ORDER BY timestamp DESC
-                    LIMIT ?
-                """,
+                    f"{self._PACKET_LIST_SELECT_RAW if include_raw else self._PACKET_LIST_SELECT_PLAIN}"
+                    " ORDER BY timestamp DESC LIMIT ?",
                     (limit,),
                 ).fetchall()
 
@@ -2115,6 +2118,7 @@ class SQLiteHandler:
         end_timestamp: Optional[float] = None,
         limit: int = 1000,
         offset: int = 0,
+        include_raw: bool = False,
     ) -> list:
         try:
             with self._connect() as conn:
@@ -2139,18 +2143,9 @@ class SQLiteHandler:
                     where_clauses.append("timestamp <= ?")
                     params.append(end_timestamp)
 
-                base_query = """
-                    SELECT
-                        id,
-                        timestamp, type, route, length, rssi, snr, score,
-                        transmitted, is_duplicate, drop_reason, src_hash, dst_hash, path_hash,
-                        upstream_hash, upstream_hash_size,
-                        transport_codes, payload, payload_length,
-                        tx_delay_ms, rx_radio_id, tx_radio_id,
-                        packet_hash, original_path, forwarded_path,
-                        lbt_attempts, lbt_channel_busy
-                    FROM packets
-                """
+                base_query = (
+                    self._PACKET_LIST_SELECT_RAW if include_raw else self._PACKET_LIST_SELECT_PLAIN
+                )
 
                 if where_clauses:
                     query = f"{base_query} WHERE {' AND '.join(where_clauses)}"

--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -2119,13 +2119,30 @@ class SQLiteHandler:
         limit: int = 1000,
         offset: int = 0,
         include_raw: bool = False,
+        upstream_hash: Optional[str] = None,
+        upstream_hash_size: Optional[int] = None,
+        cursor: Optional[tuple[float, int]] = None,
+        fields: Optional[list[str]] = None,
     ) -> list:
+        """``cursor`` is the (timestamp, id) of the last row seen; ``fields`` projects the rows."""
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
 
                 where_clauses = []
                 params = []
+
+                if upstream_hash is not None:
+                    where_clauses.append("upstream_hash = ?")
+                    params.append(str(upstream_hash).upper())
+
+                if upstream_hash_size is not None:
+                    where_clauses.append("upstream_hash_size = ?")
+                    params.append(int(upstream_hash_size))
+
+                if cursor is not None:
+                    where_clauses.append("(timestamp < ? OR (timestamp = ? AND id < ?))")
+                    params.extend([cursor[0], cursor[0], cursor[1]])
 
                 if packet_type is not None:
                     where_clauses.append("type = ?")
@@ -2152,13 +2169,15 @@ class SQLiteHandler:
                 else:
                     query = base_query
 
-                query += " ORDER BY timestamp DESC LIMIT ? OFFSET ?"
+                query += " ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?"
                 params.append(limit)
-                params.append(offset)
+                params.append(0 if cursor is not None else offset)
 
-                packets = conn.execute(query, params).fetchall()
-
-                return [dict(row) for row in packets]
+                packets = [dict(row) for row in conn.execute(query, params).fetchall()]
+                if fields:
+                    keep = set(fields) | {"id", "timestamp"}
+                    packets = [{k: v for k, v in row.items() if k in keep} for row in packets]
+                return packets
 
         except Exception as e:
             logger.error(f"Failed to get filtered packets: {e}")

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -451,8 +451,8 @@ class StorageCollector:
     def get_packet_stats(self, hours: int = 24) -> dict:
         return self.sqlite_handler.get_packet_stats(hours)
 
-    def get_recent_packets(self, limit: int = 100) -> list:
-        return self.sqlite_handler.get_recent_packets(limit)
+    def get_recent_packets(self, limit: int = 100, include_raw: bool = False) -> list:
+        return self.sqlite_handler.get_recent_packets(limit, include_raw=include_raw)
 
     def get_filtered_packets(
         self,
@@ -462,9 +462,16 @@ class StorageCollector:
         end_timestamp: Optional[float] = None,
         limit: int = 1000,
         offset: int = 0,
+        include_raw: bool = False,
     ) -> list:
         return self.sqlite_handler.get_filtered_packets(
-            packet_type, route, start_timestamp, end_timestamp, limit, offset
+            packet_type,
+            route,
+            start_timestamp,
+            end_timestamp,
+            limit,
+            offset,
+            include_raw=include_raw,
         )
 
     def get_airtime_data(

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -463,6 +463,7 @@ class StorageCollector:
         limit: int = 1000,
         offset: int = 0,
         include_raw: bool = False,
+        **query,
     ) -> list:
         return self.sqlite_handler.get_filtered_packets(
             packet_type,
@@ -472,6 +473,7 @@ class StorageCollector:
             limit,
             offset,
             include_raw=include_raw,
+            **query,
         )
 
     def get_airtime_data(

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -3896,10 +3896,12 @@ class APIEndpoints:
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def recent_packets(self, limit=100):
+    def recent_packets(self, limit=100, include_raw=None):
         try:
             limit = int(limit)
-            packets = self._get_storage().get_recent_packets(limit=limit)
+            packets = self._get_storage().get_recent_packets(
+                limit=limit, include_raw=str(include_raw).lower() in ("true", "1", "yes")
+            )
             return self._success(packets, count=len(packets))
         except Exception as e:
             logger.error(f"Error getting recent packets: {e}")
@@ -3908,13 +3910,16 @@ class APIEndpoints:
     @cherrypy.expose
     @cherrypy.tools.gzip(compress_level=6)
     @cherrypy.tools.json_out()
-    def bulk_packets(self, limit=1000, offset=0, start_timestamp=None, end_timestamp=None):
+    def bulk_packets(
+        self, limit=1000, offset=0, start_timestamp=None, end_timestamp=None, include_raw=None
+    ):
         """
         Optimized bulk packet retrieval with gzip compression and DB-level pagination.
         """
         try:
-            # Enforce reasonable limits
-            limit = min(int(limit), 10000)
+            # Enforce reasonable limits; raw frames make a page several times heavier
+            include_raw = str(include_raw).lower() in ("true", "1", "yes")
+            limit = min(int(limit), 1000 if include_raw else 10000)
             offset = max(int(offset), 0)
 
             # Get packets from storage with TRUE DB-level pagination
@@ -3927,6 +3932,7 @@ class APIEndpoints:
                 end_timestamp=float(end_timestamp) if end_timestamp else None,
                 limit=limit,
                 offset=offset,
+                include_raw=include_raw,
             )
 
             response = {
@@ -3947,7 +3953,13 @@ class APIEndpoints:
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def filtered_packets(
-        self, start_timestamp=None, end_timestamp=None, limit=1000, type=None, route=None
+        self,
+        start_timestamp=None,
+        end_timestamp=None,
+        limit=1000,
+        type=None,
+        route=None,
+        include_raw=None,
     ):
         # Handle OPTIONS request for CORS preflight
         if cherrypy.request.method == "OPTIONS":
@@ -3968,6 +3980,7 @@ class APIEndpoints:
                 start_timestamp=start_ts,
                 end_timestamp=end_ts,
                 limit=limit_int,
+                include_raw=str(include_raw).lower() in ("true", "1", "yes"),
             )
             return self._success(
                 packets,

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -3911,16 +3911,36 @@ class APIEndpoints:
     @cherrypy.tools.gzip(compress_level=6)
     @cherrypy.tools.json_out()
     def bulk_packets(
-        self, limit=1000, offset=0, start_timestamp=None, end_timestamp=None, include_raw=None
+        self,
+        limit=1000,
+        offset=0,
+        start_timestamp=None,
+        end_timestamp=None,
+        include_raw=None,
+        upstream_hash=None,
+        upstream_hash_size=None,
+        cursor=None,
+        fields=None,
     ):
         """
         Optimized bulk packet retrieval with gzip compression and DB-level pagination.
+
+        ``cursor`` is the ``next_cursor`` of the previous page (keyset paging on
+        timestamp and id); ``fields`` is a comma-separated projection.
         """
         try:
             # Enforce reasonable limits; raw frames make a page several times heavier
             include_raw = str(include_raw).lower() in ("true", "1", "yes")
             limit = min(int(limit), 1000 if include_raw else 10000)
             offset = max(int(offset), 0)
+            cursor_key = None
+            if cursor:
+                ts_text, _, id_text = str(cursor).partition(":")
+                cursor_key = (float(ts_text), int(id_text))
+            field_list = None
+            if fields:
+                field_list = [f.strip() for f in str(fields).split(",") if f.strip()]
+                include_raw = include_raw or "raw_packet" in field_list
 
             # Get packets from storage with TRUE DB-level pagination
             # Uses SQL "LIMIT ? OFFSET ?" - no Python slicing needed!
@@ -3933,8 +3953,13 @@ class APIEndpoints:
                 limit=limit,
                 offset=offset,
                 include_raw=include_raw,
+                upstream_hash=upstream_hash or None,
+                upstream_hash_size=int(upstream_hash_size) if upstream_hash_size else None,
+                cursor=cursor_key,
+                fields=field_list,
             )
 
+            last = packets[-1] if len(packets) >= limit else None
             response = {
                 "success": True,
                 "data": packets,
@@ -3942,10 +3967,13 @@ class APIEndpoints:
                 "offset": offset,
                 "limit": limit,
                 "compressed": True,
+                "next_cursor": f"{last['timestamp']}:{last['id']}" if last else None,
             }
 
             return response
 
+        except ValueError as e:
+            return self._error(f"Invalid parameter format: {e}")
         except Exception as e:
             logger.error(f"Error getting bulk packets: {e}")
             return self._error(e)

--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -874,6 +874,12 @@ paths:
             minimum: 1
             maximum: 1000
           description: Maximum number of packets to return
+        - name: include_raw
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Add each packet's raw frame (raw_packet, hex) to the rows
       responses:
         '200':
           description: Recent packets
@@ -995,6 +1001,12 @@ paths:
             type: integer
             default: 1000
           description: Maximum results
+        - name: include_raw
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Add each packet's raw frame (raw_packet, hex) to the rows
       responses:
         '200':
           description: Filtered packets
@@ -3707,6 +3719,12 @@ paths:
           in: query
           schema:
             type: number
+        - name: include_raw
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Add each packet's raw frame (raw_packet, hex) to the rows
       responses:
         '200':
           description: Bulk packet result

--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -3725,9 +3725,28 @@ paths:
             type: boolean
             default: false
           description: Add each packet's raw frame (raw_packet, hex) to the rows
+        - name: upstream_hash
+          in: query
+          schema:
+            type: string
+          description: Only packets heard from this upstream hash
+        - name: upstream_hash_size
+          in: query
+          schema:
+            type: integer
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          description: The previous page's `next_cursor`; keyset paging on (timestamp, id), ignores `offset`
+        - name: fields
+          in: query
+          schema:
+            type: string
+          description: Comma-separated columns to return (id and timestamp always included)
       responses:
         '200':
-          description: Bulk packet result
+          description: Bulk packet result; `next_cursor` is null on the last page
           content:
             application/json:
               schema:

--- a/tests/test_api_endpoints_core_coverage.py
+++ b/tests/test_api_endpoints_core_coverage.py
@@ -1057,6 +1057,10 @@ def test_recent_packets_and_bulk_packets(cherrypy_ctx):
         limit=10000,
         offset=0,
         include_raw=False,
+        upstream_hash=None,
+        upstream_hash_size=None,
+        cursor=None,
+        fields=None,
     )
 
 
@@ -1078,6 +1082,30 @@ def test_packet_lists_read_the_include_raw_flag(cherrypy_ctx):
         True,
         True,
     ]
+
+
+def test_bulk_packets_cursor_fields_and_filters(cherrypy_ctx):
+    del cherrypy_ctx
+    api = _make_api()
+    rows = [{"id": 9, "timestamp": 200.0}, {"id": 4, "timestamp": 100.0}]
+    storage = SimpleNamespace(get_filtered_packets=MagicMock(return_value=rows))
+    _attach_storage(api, storage)
+
+    result = api.bulk_packets(
+        limit="2",
+        cursor="300.5:12",
+        fields="rssi, raw_packet",
+        upstream_hash="ab",
+        upstream_hash_size="1",
+    )
+    assert result["next_cursor"] == "100.0:4"
+    kwargs = storage.get_filtered_packets.call_args.kwargs
+    assert kwargs["cursor"] == (300.5, 12)
+    assert (kwargs["fields"], kwargs["include_raw"]) == (["rssi", "raw_packet"], True)
+    assert (kwargs["upstream_hash"], kwargs["upstream_hash_size"]) == ("ab", 1)
+
+    assert api.bulk_packets(limit="5")["next_cursor"] is None
+    assert api.bulk_packets(cursor="junk")["success"] is False
 
 
 def test_filtered_packets_options_and_success(cherrypy_ctx):

--- a/tests/test_api_endpoints_core_coverage.py
+++ b/tests/test_api_endpoints_core_coverage.py
@@ -1048,7 +1048,7 @@ def test_recent_packets_and_bulk_packets(cherrypy_ctx):
     assert bulk["limit"] == 10000
     assert bulk["compressed"] is True
 
-    storage.get_recent_packets.assert_called_once_with(limit=2)
+    storage.get_recent_packets.assert_called_once_with(limit=2, include_raw=False)
     storage.get_filtered_packets.assert_called_once_with(
         packet_type=None,
         route=None,
@@ -1056,7 +1056,28 @@ def test_recent_packets_and_bulk_packets(cherrypy_ctx):
         end_timestamp=3.5,
         limit=10000,
         offset=0,
+        include_raw=False,
     )
+
+
+def test_packet_lists_read_the_include_raw_flag(cherrypy_ctx):
+    del cherrypy_ctx
+    api = _make_api()
+    storage = SimpleNamespace(
+        get_recent_packets=MagicMock(return_value=[]),
+        get_filtered_packets=MagicMock(return_value=[]),
+    )
+    _attach_storage(api, storage)
+
+    api.recent_packets("5", include_raw="1")
+    assert api.bulk_packets(limit="5000", include_raw="true")["limit"] == 1000
+    api.filtered_packets(limit="5", include_raw="yes")
+
+    storage.get_recent_packets.assert_called_once_with(limit=5, include_raw=True)
+    assert [c.kwargs["include_raw"] for c in storage.get_filtered_packets.call_args_list] == [
+        True,
+        True,
+    ]
 
 
 def test_filtered_packets_options_and_success(cherrypy_ctx):
@@ -1093,6 +1114,7 @@ def test_filtered_packets_options_and_success(cherrypy_ctx):
         start_timestamp=10.0,
         end_timestamp=20.0,
         limit=5,
+        include_raw=False,
     )
 
 

--- a/tests/test_sqlite_handler_easy.py
+++ b/tests/test_sqlite_handler_easy.py
@@ -349,6 +349,27 @@ def test_recent_packet_queries_include_ids_and_preserve_duplicate_hash_rows(tmp_
     assert by_id["packet_hash"] == "same-hash"
 
 
+def test_packet_list_queries_add_raw_frame_only_on_request(tmp_path):
+    h = _make_handler(tmp_path)
+    h.store_packet(
+        {
+            "timestamp": 100.0,
+            "type": 2,
+            "route": 1,
+            "length": 12,
+            "transmitted": False,
+            "is_duplicate": False,
+            "packet_hash": "with-frame",
+            "raw_packet": "0901aa55",
+        }
+    )
+    assert "raw_packet" not in h.get_recent_packets(limit=10)[0]
+    assert "raw_packet" not in h.get_filtered_packets(limit=10)[0]
+    assert h.get_recent_packets(limit=10, include_raw=True)[0]["raw_packet"] == "0901aa55"
+    windowed = h.get_filtered_packets(start_timestamp=50.0, limit=10, include_raw=True)
+    assert windowed[0]["raw_packet"] == "0901aa55"
+
+
 def test_verify_api_token_last_used_throttle(tmp_path, monkeypatch):
     h = _make_handler(tmp_path)
     h._api_token_last_used_interval_sec = 300

--- a/tests/test_sqlite_handler_easy.py
+++ b/tests/test_sqlite_handler_easy.py
@@ -370,6 +370,37 @@ def test_packet_list_queries_add_raw_frame_only_on_request(tmp_path):
     assert windowed[0]["raw_packet"] == "0901aa55"
 
 
+def test_filtered_packets_cursor_order_filter_and_fields(tmp_path):
+    h = _make_handler(tmp_path)
+    for i, (ts, up) in enumerate([(100.0, "AA"), (100.0, "AA"), (100.0, "BB"), (200.0, "AA")]):
+        h.store_packet(
+            {
+                "timestamp": ts,
+                "type": 2,
+                "route": 1,
+                "length": 10,
+                "rssi": -90 - i,
+                "packet_hash": f"p{i}",
+                "upstream_hash": up,
+                "upstream_hash_size": 1,
+                "original_path": [up],
+            }
+        )
+
+    page = h.get_filtered_packets(limit=2)
+    assert [r["packet_hash"] for r in page] == ["p3", "p2"]
+    cursor = (page[-1]["timestamp"], page[-1]["id"])
+    assert [r["packet_hash"] for r in h.get_filtered_packets(limit=2, cursor=cursor)] == [
+        "p1",
+        "p0",
+    ]
+    assert h.get_filtered_packets(limit=2, cursor=(100.0, page[-1]["id"] - 2)) == []
+
+    aa = h.get_filtered_packets(limit=10, upstream_hash="aa", upstream_hash_size=1, fields=["rssi"])
+    assert [r["rssi"] for r in aa] == [-93, -91, -90]
+    assert set(aa[0]) == {"id", "timestamp", "rssi"}
+
+
 def test_verify_api_token_last_used_throttle(tmp_path, monkeypatch):
     h = _make_handler(tmp_path)
     h._api_token_last_used_interval_sec = 300

--- a/tests/test_storage_collector_packet_lists.py
+++ b/tests/test_storage_collector_packet_lists.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from repeater.data_acquisition.storage_collector import StorageCollector
+
+
+def test_packet_list_wrappers_forward_include_raw():
+    collector = StorageCollector.__new__(StorageCollector)
+    collector.sqlite_handler = Mock()
+    collector.get_recent_packets(limit=25, include_raw=True)
+    collector.sqlite_handler.get_recent_packets.assert_called_once_with(25, include_raw=True)
+    collector.get_filtered_packets(limit=10, offset=5)
+    collector.sqlite_handler.get_filtered_packets.assert_called_once_with(
+        None, None, None, None, 10, 5, include_raw=False
+    )

--- a/tests/test_storage_collector_packet_lists.py
+++ b/tests/test_storage_collector_packet_lists.py
@@ -8,7 +8,7 @@ def test_packet_list_wrappers_forward_include_raw():
     collector.sqlite_handler = Mock()
     collector.get_recent_packets(limit=25, include_raw=True)
     collector.sqlite_handler.get_recent_packets.assert_called_once_with(25, include_raw=True)
-    collector.get_filtered_packets(limit=10, offset=5)
+    collector.get_filtered_packets(limit=10, offset=5, cursor=(1.0, 2))
     collector.sqlite_handler.get_filtered_packets.assert_called_once_with(
-        None, None, None, None, 10, 5, include_raw=False
+        None, None, None, None, 10, 5, include_raw=False, cursor=(1.0, 2)
     )


### PR DESCRIPTION
Stacked on #444 (its commit comes first). Adds keyset paging to `GET /api/bulk_packets`:

- `cursor`: the previous page's `next_cursor`, `(timestamp, id)` of its last row. `offset` still works and is ignored when a cursor is given. `next_cursor` is null on the last page.

Nothing else changes. The console's loader pages by timestamp today and uses `offset` only to skip rows tied at the boundary, under a page budget, because the API has no cursor; this gives it one that stays exact under retroactive writes. `openapi.yaml` updated; one test per layer.

`pre-commit` is red at baseline on `dev` (formatter drift, IPC timeout test); untouched here.
