### PR TITLE
Fix/cli text type filter

### DIFF
--- a/repeater/engine.py
+++ b/repeater/engine.py
@@ -1,9 +1,11 @@
 import asyncio
 import copy
 import logging
+import math
 import secrets
 import time
 from collections import OrderedDict, deque
+from collections.abc import Mapping
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -1514,6 +1516,102 @@ class RepeaterHandler(BaseHandler):
             packet.drop_reason = f"Unknown route type: {route_type}"
             return None
 
+    # A local transmit whose radio link has dropped waits this long for it to come
+    # back before giving up, polling at LOCAL_TX_LINK_POLL_S. Kept well inside the
+    # companion client's own command timeout (meshcore_py: 15s), which is already
+    # partly spent on the TX delay by the time we get here.
+    DEFAULT_LOCAL_TX_LINK_WAIT_S = 5.0
+    # Hard ceiling regardless of configuration: the companion client is already
+    # waiting on this send, and an unbounded (or infinite) value would hold its
+    # command open forever rather than reporting a failure it can act on.
+    MAX_LOCAL_TX_LINK_WAIT_S = 30.0
+    LOCAL_TX_LINK_POLL_S = 0.1
+
+    def _local_tx_link_wait_s(self) -> float:
+        """Configured ceiling for waiting out a radio-link outage on a local TX."""
+        delays = self.config.get("delays") or {}
+        try:
+            wait = float(
+                delays.get("local_tx_link_wait_seconds", self.DEFAULT_LOCAL_TX_LINK_WAIT_S)
+            )
+        except (TypeError, ValueError):
+            return self.DEFAULT_LOCAL_TX_LINK_WAIT_S
+        if not math.isfinite(wait):
+            logger.warning(
+                "local_tx_link_wait_seconds=%r is not a finite number; using %.1fs",
+                wait,
+                self.DEFAULT_LOCAL_TX_LINK_WAIT_S,
+            )
+            return self.DEFAULT_LOCAL_TX_LINK_WAIT_S
+        return min(max(0.0, wait), self.MAX_LOCAL_TX_LINK_WAIT_S)
+
+    def _resolve_tx_radio(self, radio_id: Optional[str] = None):
+        """The radio a send will actually use, or None when that cannot be told.
+
+        Attribute access on a FabricRadio passes through to its *default* endpoint
+        (rf_fabric/fabric.py), so reading link state off it while the send targets
+        another radio_id answers about the wrong radio -- suppressing a healthy one,
+        or waving through a dead one. Resolve the named endpoint instead, and return
+        None rather than guess: no answer leaves the send to proceed as before.
+        """
+        radio = getattr(self.dispatcher, "radio", None)
+        if radio is None:
+            return None
+        fabric = getattr(radio, "fabric", None)
+        if fabric is None and hasattr(radio, "get_radio"):
+            fabric = radio  # an RFFabric handed to the dispatcher directly
+        radios = getattr(fabric, "radios", None) if fabric is not None else None
+        # isinstance, not truthiness: RFFabric.radios is an OrderedDict, so this
+        # recognises a real multi-endpoint fabric without mistaking a stand-in
+        # attribute on a single-radio wrapper for one.
+        if not isinstance(radios, Mapping) or len(radios) <= 1:
+            return radio  # one radio, and it is the one that transmits
+        if not radio_id:
+            # The fabric picks its endpoint at send time, so there is nothing here
+            # to inspect. Say so rather than answer about whichever radio happens
+            # to be the default -- a wrong "down" would suppress a healthy send.
+            return None
+        getter = getattr(fabric, "get_radio", None)
+        if getter is None:
+            return None
+        try:
+            return getter(str(radio_id))
+        except Exception:
+            return None
+
+    def _radio_link_down(self, radio_id: Optional[str] = None) -> bool:
+        """True when the radio this send will use reports its link unusable.
+
+        Only radios that track a link state answer this -- a KISS modem over serial
+        does, a directly-driven SX1262 has none to lose -- so it reads False for the
+        rest and leaves their timing untouched.
+        """
+        radio = self._resolve_tx_radio(radio_id)
+        if radio is None:
+            return False
+        # Identity checks, not truthiness: a radio that does not track link state
+        # answers with something that is neither True nor False (or nothing at all),
+        # and that has to read as "no opinion" rather than "down".
+        if getattr(radio, "is_connected", None) is False:
+            return True
+        return getattr(radio, "is_degraded", None) is True
+
+    async def _await_radio_link(self, timeout: float, radio_id: Optional[str] = None) -> bool:
+        """Wait up to *timeout* seconds for the radio link, True if it is usable."""
+        if not self._radio_link_down(radio_id):
+            return True
+        if timeout <= 0:
+            return False
+        logger.info("Local TX: radio link down, waiting up to %.1fs for it", timeout)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            await asyncio.sleep(self.LOCAL_TX_LINK_POLL_S)
+            if not self._radio_link_down(radio_id):
+                logger.info("Local TX: radio link back, transmitting now")
+                return True
+        logger.warning("Local TX: radio link still down after %.1fs, giving up", timeout)
+        return False
+
     async def schedule_retransmit(
         self,
         fwd_pkt: Packet,
@@ -1540,10 +1638,21 @@ class RepeaterHandler(BaseHandler):
             #   attempt 0 — initial try (no pre-sleep)
             #   attempt 1 — retry after 1s backoff outside the lock
             for attempt in range(2 if local_transmission else 1):
-                if attempt > 0:
-                    # Back-off OUTSIDE the lock — other tasks can transmit here.
+                if attempt > 0 and not self._radio_link_down(preferred_tx_radio_id):
+                    # A transient failure with the link still up: back off OUTSIDE
+                    # the lock — other tasks can transmit here.
                     logger.info("Retrying local TX in 1s (lock released during backoff)...")
                     await asyncio.sleep(1.0)
+
+                # A dropped link is not a transient failure to back off from. A KISS
+                # modem that falls off USB re-enumerates and re-handshakes in ~2s, so
+                # the flat backoff above would land inside the outage and spend the
+                # retry on a link that is still down — which is exactly what turned
+                # one modem hiccup into a failed message. Wait for the link instead.
+                if local_transmission and not await self._await_radio_link(
+                    self._local_tx_link_wait_s(), preferred_tx_radio_id
+                ):
+                    return False
 
                 async with self._tx_lock:
                     # ── Authoritative duty-cycle gate ──────────────────────────

--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -399,6 +399,15 @@ class RoomServer:
             # (from before this limit was enforced on write) exceeds
             # MAX_POST_TEXT_LEN bytes -- truncate at a UTF-8 codepoint boundary.
             message_text = post["message_text"]
+            # The body is a C string on the wire: pushPostToClient sizes it with
+            # `strlen(post.text)` for both the payload and the expected ACK. A
+            # post stored with an interior NUL (the web API accepts one) would
+            # otherwise be transmitted and hashed whole, while the receiver
+            # stops at that NUL -- so its ACK would never match ours and the
+            # push would retry until it hit the failure backoff.
+            nul = message_text.find("\x00")
+            if nul >= 0:
+                message_text = message_text[:nul]
             if len(message_text.encode("utf-8")) > MAX_POST_TEXT_LEN:
                 message_text = _truncate_utf8(message_text, MAX_POST_TEXT_LEN)
             message_bytes = message_text.encode("utf-8")

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -107,6 +107,12 @@ def _may_ack(identity_type, client, txt_type, sender_timestamp) -> bool:
     A retry (equal timestamp) *is* acknowledged by both -- firmware suppresses
     the work, not the answer -- so only a strictly older stamp fails here.
 
+    This predicts *eligibility*, not the outcome. A post that clears the role
+    and replay checks and is then refused by ``add_post`` -- openHop's own
+    per-client rate limit, or a database error, neither of which firmware has --
+    is still acknowledged. Closing that would mean feeding the store result back
+    to an ACK the core handler has already scheduled.
+
     ``txt_type is None`` means a core too old to publish it; there is nothing to
     judge, so keep the previous behaviour rather than silently going quiet.
     """

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -20,9 +20,25 @@ from .room_server import RoomServer
 logger = logging.getLogger("TextHelper")
 
 
-# Text message type flags
+# Text message type flags (firmware TxtDataHelpers.h)
 TXT_TYPE_PLAIN = 0x00
 TXT_TYPE_CLI_DATA = 0x01
+TXT_TYPE_SIGNED_PLAIN = 0x02
+TXT_TYPE_CLI_COMMAND = 0x03
+
+# The text types a server acts on. Both simple_repeater::onPeerDataRecv and
+# simple_room_server::onPeerDataRecv open their TXT_MSG branch with
+#
+#     if (!(flags == TXT_TYPE_PLAIN || flags == TXT_TYPE_CLI_DATA
+#           || flags == TXT_TYPE_CLI_COMMAND)) {
+#       MESH_DEBUG_PRINTLN("unsupported text type received: flags=%02x", flags);
+#     } else if (...)
+#
+# so anything else -- SIGNED_PLAIN included -- is logged and dropped: no
+# command run, no post stored, no reply. CLI_COMMAND joined the set when
+# firmware split "a CLI command" out of CLI_DATA (MeshCore 2c0ace25); CLI_DATA
+# stays in it because that is what every released client still sends.
+SERVER_TXT_TYPES = frozenset((TXT_TYPE_PLAIN, TXT_TYPE_CLI_DATA, TXT_TYPE_CLI_COMMAND))
 
 
 class TextHelper:
@@ -286,6 +302,22 @@ class TextHelper:
         # Extract decrypted message if available
         if hasattr(packet, "decrypted") and packet.decrypted:
             message_text = packet.decrypted.get("text", "<unknown>")
+
+            # Firmware gates the whole TXT_MSG branch on the text type before it
+            # looks at the text at all. Without this, a SIGNED_PLAIN — a room
+            # post, whose 4-byte author prefix the core handler has already
+            # split off, leaving bare text — reaches the repeater's CLI and runs
+            # as a command whenever it happens to start with a command prefix.
+            # A core older than the one that publishes ``txt_type`` reports
+            # None; behave as before rather than dropping every message.
+            txt_type = packet.decrypted.get("txt_type")
+            if txt_type is not None and txt_type not in SERVER_TXT_TYPES:
+                logger.debug(
+                    f"[{identity_type}:{identity_name}] unsupported text type "
+                    f"{txt_type} from 0x{src_hash:02X}; dropping"
+                )
+                return
+
             sender_client = self._resolve_sender_client(dest_hash, src_hash, packet)
 
             # Clean message text - remove null bytes and trailing whitespace

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -41,6 +41,36 @@ TXT_TYPE_CLI_COMMAND = 0x03
 SERVER_TXT_TYPES = frozenset((TXT_TYPE_PLAIN, TXT_TYPE_CLI_DATA, TXT_TYPE_CLI_COMMAND))
 
 
+def _accept_once(client, sender_timestamp) -> tuple[bool, bool]:
+    """Firmware's TXT_MSG replay guard. Returns ``(accepted, is_retry)``.
+
+    ``simple_repeater`` and ``simple_room_server`` both open the branch with
+    ``sender_timestamp >= client->last_timestamp``: an older timestamp is a
+    replay and is dropped whole, an equal one is a *retry* — accepted, activity
+    refreshed, but the command not re-run and the post not re-added — and a
+    newer one is fresh work. The watermark advances either way.
+
+    Note the deliberate difference from ``ACL._is_replay``, which rejects the
+    equal case: that matches the REQ branch (``timestamp > last_timestamp``),
+    not this one.
+
+    An unresolved client or a core too old to publish the timestamp yields
+    ``(True, False)`` — no watermark to check against, so behave as before.
+    """
+    if client is None or sender_timestamp is None:
+        return True, False
+    last = int(getattr(client, "last_timestamp", 0) or 0)
+    if sender_timestamp < last:
+        logger.warning(
+            f"Possible replay: text timestamp={sender_timestamp} < last={last}; dropping"
+        )
+        return False, False
+    is_retry = sender_timestamp == last
+    client.last_timestamp = sender_timestamp
+    client.last_activity = int(time.time())
+    return True, is_retry
+
+
 def _is_guest_client(client) -> bool:
     """True when ``client`` holds the GUEST role (firmware ``PERM_ACL_GUEST``).
 
@@ -323,11 +353,12 @@ class TextHelper:
             # A core older than the one that publishes ``txt_type`` reports
             # None; behave as before rather than dropping every message.
             txt_type = packet.decrypted.get("txt_type")
-            if txt_type is None:
+            sender_timestamp = packet.decrypted.get("sender_timestamp")
+            if txt_type is None or sender_timestamp is None:
                 logger.warning(
-                    "TXT_MSG carried no txt_type: openhop_core is older than the "
-                    "build that publishes it, so the text-type gate is open and a "
-                    "signed post can reach the CLI. Upgrade openhop_core."
+                    "TXT_MSG carried no txt_type/sender_timestamp: openhop_core is "
+                    "older than the build that publishes them, so the text-type "
+                    "gate and the replay guard are open. Upgrade openhop_core."
                 )
             if txt_type is not None and txt_type not in SERVER_TXT_TYPES:
                 logger.debug(
@@ -338,6 +369,15 @@ class TextHelper:
 
             sender_client = self._resolve_sender_client(dest_hash, src_hash, packet)
 
+            # Firmware checks the type, then the replay watermark, and only then
+            # looks at the message. A retry is accepted but re-runs nothing.
+            accepted, is_retry = _accept_once(sender_client, sender_timestamp)
+            if not accepted:
+                logger.warning(
+                    f"[{identity_type}:{identity_name}] replay from 0x{src_hash:02X}; dropping"
+                )
+                return
+
             # Clean message text - remove null bytes and trailing whitespace
             message_text = message_text.rstrip("\x00").rstrip()
 
@@ -347,8 +387,19 @@ class TextHelper:
             if identity_type == "room_server" and dest_hash in self.room_servers:
                 room_server = self.room_servers[dest_hash]
 
-                # Check if this is a CLI command FIRST (before storing as post)
-                if self._is_cli_command(message_text):
+                # simple_room_server::onPeerDataRecv splits by *type*, not by
+                # text: CLI_DATA/CLI_COMMAND go to the admin CLI, PLAIN becomes
+                # a post. Deciding from the text instead got both wrong -- a
+                # PLAIN "set ..." ran as a command instead of being posted, and
+                # a command whose text was not in the prefix list was published
+                # to the room.
+                if txt_type is None:
+                    # Older core: no type to dispatch on, keep the text test.
+                    room_is_command = self._is_cli_command(message_text)
+                else:
+                    room_is_command = txt_type in (TXT_TYPE_CLI_DATA, TXT_TYPE_CLI_COMMAND)
+
+                if room_is_command:
                     # Handle CLI command - do NOT store as post
                     if room_server and room_server.cli:
                         try:
@@ -367,6 +418,16 @@ class TextHelper:
                             sender_pubkey = bytes([src_hash]) + b"\x00" * 31  # Default
                             if sender_client is not None:
                                 sender_pubkey = sender_client.id.get_public_key()
+
+                            # A retry re-sends the same command; firmware
+                            # answers it with an empty reply rather than running
+                            # it a second time.
+                            if is_retry:
+                                logger.info(
+                                    f"Room '{identity_name}': retry of command from "
+                                    f"0x{src_hash:02X}; not re-running"
+                                )
+                                return
 
                             # Handle CLI command
                             reply = room_server.cli.handle_command(
@@ -409,6 +470,15 @@ class TextHelper:
                     )
                     return
 
+                # Firmware calls addPost only when `!is_retry`, so a resent post
+                # does not appear in the room twice.
+                if is_retry:
+                    logger.info(
+                        f"Room '{identity_name}': retry of post from 0x{src_hash:02X}; "
+                        "not storing again"
+                    )
+                    return
+
                 try:
                     # Get sender's full pubkey
                     sender_pubkey = bytes([src_hash]) + b"\x00" * 31  # Default
@@ -434,8 +504,16 @@ class TextHelper:
 
                 return
 
-            # Check if this is a CLI command to the repeater (AFTER decryption)
-            if dest_hash == self.repeater_hash and self.cli and self._is_cli_command(message_text):
+            # A repeater has no chat function, so simple_repeater::onPeerDataRecv
+            # runs *every* accepted type from an admin through handleCommand with
+            # no text test at all. Matching that means a plain DM to the repeater
+            # is a command too -- which it always was; openHop simply dropped the
+            # ones whose text did not match a prefix.
+            if txt_type is None and not self._is_cli_command(message_text):
+                # Older core: no type to dispatch on, keep the text test.
+                return
+
+            if dest_hash == self.repeater_hash and self.cli:
                 try:
                     repeater_hash = self.repeater_hash
                     if repeater_hash is None:
@@ -457,6 +535,12 @@ class TextHelper:
                     sender_pubkey = bytes([src_hash]) + b"\x00" * 31  # Default
                     if sender_client is not None:
                         sender_pubkey = sender_client.id.get_public_key()
+
+                    # A retry re-sends the same command; firmware answers it
+                    # with an empty reply rather than running it again.
+                    if is_retry:
+                        logger.info(f"Retry of command from 0x{src_hash:02X}; not re-running")
+                        return
 
                     # Handle CLI command
                     reply = self.cli.handle_command(

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -13,7 +13,7 @@ import time
 from openhop_core.node.handlers.text import TextMessageHandler
 from openhop_core.protocol import CryptoUtils, Identity
 
-from .acl import is_admin_permissions
+from .acl import PERM_ACL_GUEST, PERM_ACL_ROLE_MASK, is_admin_permissions
 from .mesh_cli import MeshCLI
 from .room_server import RoomServer
 
@@ -39,6 +39,18 @@ TXT_TYPE_CLI_COMMAND = 0x03
 # firmware split "a CLI command" out of CLI_DATA (MeshCore 2c0ace25); CLI_DATA
 # stays in it because that is what every released client still sends.
 SERVER_TXT_TYPES = frozenset((TXT_TYPE_PLAIN, TXT_TYPE_CLI_DATA, TXT_TYPE_CLI_COMMAND))
+
+
+def _is_guest_client(client) -> bool:
+    """True when ``client`` holds the GUEST role (firmware ``PERM_ACL_GUEST``).
+
+    Falls back to the role bits for a client object with no ``is_guest``
+    helper, so an older ACL shape still fails closed.
+    """
+    is_guest = getattr(client, "is_guest", None)
+    if callable(is_guest):
+        return bool(is_guest())
+    return (getattr(client, "permissions", 0) & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST
 
 
 class TextHelper:
@@ -311,6 +323,12 @@ class TextHelper:
             # A core older than the one that publishes ``txt_type`` reports
             # None; behave as before rather than dropping every message.
             txt_type = packet.decrypted.get("txt_type")
+            if txt_type is None:
+                logger.warning(
+                    "TXT_MSG carried no txt_type: openhop_core is older than the "
+                    "build that publishes it, so the text-type gate is open and a "
+                    "signed post can reach the CLI. Upgrade openhop_core."
+                )
             if txt_type is not None and txt_type not in SERVER_TXT_TYPES:
                 logger.debug(
                     f"[{identity_type}:{identity_name}] unsupported text type "
@@ -378,6 +396,19 @@ class TextHelper:
                     return
 
                 # NOT a CLI command - store as regular room post
+                #
+                # A guest may read the room but not write to it:
+                # simple_room_server::onPeerDataRecv takes the
+                # `(client->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST`
+                # branch for a PLAIN message and stores nothing (and sends no
+                # ACK). Without this, anyone who can log in with the guest
+                # password can post to the room.
+                if sender_client is not None and _is_guest_client(sender_client):
+                    logger.warning(
+                        f"Room '{identity_name}': post denied from 0x{src_hash:02X} (guest)"
+                    )
+                    return
+
                 try:
                     # Get sender's full pubkey
                     sender_pubkey = bytes([src_hash]) + b"\x00" * 31  # Default

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -7,6 +7,7 @@ Also handles CLI commands for admin users on the repeater identity.
 """
 
 import asyncio
+import inspect
 import logging
 import time
 
@@ -18,6 +19,24 @@ from .mesh_cli import MeshCLI
 from .room_server import RoomServer
 
 logger = logging.getLogger("TextHelper")
+
+
+def _core_accepts_ack_policy() -> bool:
+    """Does the installed openhop_core's text handler take ``should_ack_fn``?
+
+    Passing an argument an older core does not know raises TypeError from
+    ``register_identity`` -- which would leave the node with no text handler at
+    all, i.e. off the air. `pyproject.toml` tracks `openhop_core@dev` with no
+    version floor, so an older core is an ordinary state to be in, not an
+    error.
+    """
+    try:
+        return "should_ack_fn" in inspect.signature(TextMessageHandler.__init__).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic/absent signature
+        return False
+
+
+CORE_ACCEPTS_ACK_POLICY = _core_accepts_ack_policy()
 
 
 # Text message type flags (firmware TxtDataHelpers.h)
@@ -69,6 +88,41 @@ def _accept_once(client, sender_timestamp) -> tuple[bool, bool]:
     client.last_timestamp = sender_timestamp
     client.last_activity = int(time.time())
     return True, is_retry
+
+
+def _may_ack(identity_type, client, txt_type, sender_timestamp) -> bool:
+    """Firmware's delivery-ACK rule for a server identity. Read-only.
+
+    A server answers far less than a chat node does, and decides *before* it
+    answers, so nothing it refuses is ever acknowledged:
+
+    - ``simple_repeater``: only ``TXT_TYPE_PLAIN``, and only from an admin --
+      the whole TXT_MSG branch is gated on ``client->isAdmin()``, and inside it
+      the ACK is built only under ``if (flags == TXT_TYPE_PLAIN)``.
+    - ``simple_room_server``: only PLAIN, and only when the role is not
+      ``PERM_ACL_GUEST`` (``send_ack`` stays false on the guest branch).
+    - Neither ACKs a CLI type, an unsupported type, or a replayed timestamp:
+      those never reach the ACK at all.
+
+    A retry (equal timestamp) *is* acknowledged by both -- firmware suppresses
+    the work, not the answer -- so only a strictly older stamp fails here.
+
+    ``txt_type is None`` means a core too old to publish it; there is nothing to
+    judge, so keep the previous behaviour rather than silently going quiet.
+    """
+    if txt_type is None:
+        return True
+    if txt_type != TXT_TYPE_PLAIN:
+        return False
+    if client is None:
+        return False
+    if sender_timestamp is not None:
+        last = int(getattr(client, "last_timestamp", 0) or 0)
+        if sender_timestamp < last:
+            return False
+    if identity_type == "room_server":
+        return not _is_guest_client(client)
+    return is_admin_permissions(getattr(client, "permissions", 0))
 
 
 def _is_guest_client(client) -> bool:
@@ -157,13 +211,24 @@ class TextHelper:
         acl_contacts = self._create_acl_contacts_wrapper(identity_acl)
 
         # Create TextMessageHandler for this identity
-        handler = TextMessageHandler(
-            local_identity=identity,
-            contacts=acl_contacts,
-            log_fn=self.log_fn,
-            send_packet_fn=self._send_packet,
-            radio_config=radio_config,
-        )
+        handler_kwargs = {
+            "local_identity": identity,
+            "contacts": acl_contacts,
+            "log_fn": self.log_fn,
+            "send_packet_fn": self._send_packet,
+            "radio_config": radio_config,
+        }
+        if CORE_ACCEPTS_ACK_POLICY:
+            # The handler's own rule is BaseChatMesh's, which over-answers for a
+            # server: without this, a signed post, a non-admin command or a
+            # guest's post is ACKed there and only then refused here.
+            handler_kwargs["should_ack_fn"] = self._make_ack_policy(hash_byte, identity_type)
+        else:
+            logger.warning(
+                "openhop_core's text handler takes no should_ack_fn: it will "
+                "acknowledge messages this server then refuses. Upgrade openhop_core."
+            )
+        handler = TextMessageHandler(**handler_kwargs)
 
         # Register by dest hash
         hash_byte = identity.get_public_key()[0]
@@ -256,6 +321,41 @@ class TextHelper:
                 logger.error(f"Failed to create room server '{name}': {e}", exc_info=True)
 
         logger.info(f"Registered {identity_type} '{name}' text handler: hash=0x{hash_byte:02X}")
+
+    def _client_by_pubkey(self, identity_hash: int, pubkey: bytes):
+        """The ACL client for an already-authenticated public key.
+
+        Core hands the ACK policy the key it actually decrypted with, so this
+        is an exact lookup rather than the hash-collision search
+        ``_resolve_sender_client`` has to do from the wire.
+        """
+        identity_acl = self.acl_dict.get(identity_hash)
+        if not identity_acl:
+            return None
+        get_client = getattr(identity_acl, "get_client", None)
+        if callable(get_client):
+            client = get_client(pubkey)
+            if client is not None:
+                return client
+        for client_info in identity_acl.get_all_clients():
+            if client_info.id.get_public_key() == pubkey:
+                return client_info
+        return None
+
+    def _make_ack_policy(self, identity_hash: int, identity_type: str):
+        """Bind :func:`_may_ack` to one registered identity for the core handler."""
+
+        def _policy(sender_pubkey: bytes, txt_type: int, sender_timestamp: int) -> bool:
+            client = self._client_by_pubkey(identity_hash, sender_pubkey)
+            allowed = _may_ack(identity_type, client, txt_type, sender_timestamp)
+            if not allowed:
+                logger.debug(
+                    f"[{identity_type}] withholding ACK for txt_type={txt_type} "
+                    f"from {sender_pubkey[:4].hex()}"
+                )
+            return allowed
+
+        return _policy
 
     def _create_acl_contacts_wrapper(self, acl):
 

--- a/tests/test_handler_helpers_path_protocol_text.py
+++ b/tests/test_handler_helpers_path_protocol_text.py
@@ -459,14 +459,51 @@ def test_text_helper_cli_prefix_and_admin_permission_checks():
 
 
 class _TxtPacket:
-    """A packet as the core TextMessageHandler leaves it: text + its type."""
+    """A packet as the core TextMessageHandler leaves it.
 
-    def __init__(self, text: str, txt_type=None):
+    ``txt_type``/``sender_timestamp`` default to absent so a test can model a
+    core too old to publish them.
+    """
+
+    def __init__(self, text: str, txt_type=None, sender_timestamp=None):
         self.decrypted = {"text": text}
         if txt_type is not None:
             self.decrypted["txt_type"] = txt_type
+        if sender_timestamp is not None:
+            self.decrypted["sender_timestamp"] = sender_timestamp
         self.payload = bytearray([0x41, 0x21])
         self.mark_do_not_retransmit = MagicMock()
+
+
+def _room_helper(permissions=PERM_ACL_ADMIN):
+    """A TextHelper wired as a room-server identity with a stub CLI and store."""
+    helper = TextHelper(identity_manager=MagicMock(), acl_dict={})
+    room = MagicMock()
+    room.add_post = AsyncMock(return_value=True)
+    room.cli = MagicMock()
+    room.cli.handle_command = MagicMock(return_value="ok")
+    helper.room_servers = {0x41: room}
+    helper.handlers = {0x41: {"name": "room", "type": "room_server", "identity": MagicMock()}}
+    helper._resolve_sender_client = MagicMock(
+        return_value=_FakeClient(
+            pubkey=bytes([0x21]) + b"x" * 31,
+            shared_secret=b"k" * 32,
+            permissions=permissions,
+        )
+    )
+    helper._check_admin_permission_for_identity = MagicMock(return_value=True)
+    helper._send_cli_reply = AsyncMock()
+    return helper, room
+
+
+async def _deliver(helper, packet, identity_type="repeater", name="rep"):
+    await helper._on_message_received(
+        identity_name=name,
+        identity_type=identity_type,
+        packet=packet,
+        dest_hash=0x41,
+        src_hash=0x21,
+    )
 
 
 def _repeater_cli_helper():
@@ -500,7 +537,7 @@ def _repeater_cli_helper():
     ],
 )
 async def test_text_helper_runs_cli_only_for_server_text_types(txt_type, runs):
-    """[fails pre-fix for SIGNED_PLAIN] The text type gates the CLI, not the text.
+    """[fails pre-fix for SIGNED_PLAIN] Only the accepted types reach the CLI.
 
     simple_repeater::onPeerDataRecv opens its TXT_MSG branch by rejecting any
     flags outside {PLAIN, CLI_DATA, CLI_COMMAND}. openHop dispatched purely on
@@ -508,6 +545,9 @@ async def test_text_helper_runs_cli_only_for_server_text_types(txt_type, runs):
     whose 4-byte author prefix the core handler has already stripped, leaving
     bare text -- ran as an admin CLI command whenever it happened to start with
     a command prefix.
+
+    All three accepted types run here because a repeater has no chat function;
+    that a *plain* one runs with no text test is covered separately.
 
     ``txt_type is None`` is a core too old to report it; that must keep working
     rather than silently dropping every message.
@@ -534,34 +574,109 @@ async def test_text_helper_signed_plain_is_not_stored_as_a_room_post():
     simple_room_server::onPeerDataRecv carries the same filter as the repeater;
     only PLAIN becomes a post there. openHop stored whatever arrived.
     """
-    helper = TextHelper(identity_manager=MagicMock(), acl_dict={})
-    room = MagicMock()
-    room.add_post = AsyncMock(return_value=True)
-    room.cli = None
-    helper.room_servers = {0x41: room}
-    helper.handlers = {0x41: {"name": "room", "type": "room_server", "identity": MagicMock()}}
-    helper._resolve_sender_client = MagicMock(
-        return_value=_FakeClient(pubkey=bytes([0x21]) + b"x" * 31, shared_secret=b"k" * 32)
-    )
+    helper, room = _room_helper(permissions=PERM_ACL_READ_WRITE)
 
-    await helper._on_message_received(
-        identity_name="room",
-        identity_type="room_server",
-        packet=_TxtPacket("hello room", 2),
-        dest_hash=0x41,
-        src_hash=0x21,
-    )
+    await _deliver(helper, _TxtPacket("hello room", 2, sender_timestamp=100), "room_server", "room")
     room.add_post.assert_not_awaited()
 
-    # ...while a plain post still lands.
-    await helper._on_message_received(
-        identity_name="room",
-        identity_type="room_server",
-        packet=_TxtPacket("hello room", 0),
-        dest_hash=0x41,
-        src_hash=0x21,
-    )
+    # ...while a plain post from the same writer still lands.
+    await _deliver(helper, _TxtPacket("hello room", 0, sender_timestamp=101), "room_server", "room")
     room.add_post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "txt_type,is_command",
+    [
+        (0, False),  # PLAIN       -> a post
+        (1, True),  # CLI_DATA    -> the admin CLI
+        (3, True),  # CLI_COMMAND -> the admin CLI
+    ],
+)
+async def test_room_dispatches_on_type_not_text(txt_type, is_command):
+    """[fails pre-fix] The room splits command from post by type, as firmware does.
+
+    simple_room_server::onPeerDataRecv routes CLI_DATA/CLI_COMMAND through
+    handleCommand and turns PLAIN into a post. openHop asked
+    `_is_cli_command(message_text)` instead, so it got both wrong: a PLAIN
+    "get status" ran as a command rather than being posted, and a CLI command
+    whose text was not in the prefix list was published to the room.
+
+    Both cases use the *same* text, so only the type can decide.
+    """
+    helper, room = _room_helper()
+
+    await _deliver(
+        helper,
+        _TxtPacket("get status", txt_type, sender_timestamp=100),
+        identity_type="room_server",
+        name="room",
+    )
+
+    assert room.cli.handle_command.called is is_command
+    assert room.add_post.await_count == (0 if is_command else 1)
+
+
+@pytest.mark.asyncio
+async def test_repeater_runs_any_accepted_type_without_a_text_test():
+    """[fails pre-fix] A repeater has no chat, so every accepted type is a command.
+
+    simple_repeater::onPeerDataRecv hands PLAIN, CLI_DATA and CLI_COMMAND alike
+    to handleCommand with no text test. openHop dropped anything whose text did
+    not start with a known prefix, so an admin's mistyped command vanished
+    silently instead of being answered.
+    """
+    helper = _repeater_cli_helper()
+
+    await _deliver(helper, _TxtPacket("frobnicate", 1, sender_timestamp=100))
+
+    helper.cli.handle_command.assert_called_once()
+    assert helper.cli.handle_command.call_args.kwargs["command"] == "frobnicate"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "second_timestamp,label",
+    [(99, "older"), (100, "equal")],
+)
+async def test_repeater_command_is_not_run_twice(second_timestamp, label):
+    """[fails pre-fix] A resent command is not executed again.
+
+    simple_repeater guards on `sender_timestamp >= client->last_timestamp` and
+    treats equality as a retry it answers with an empty reply; an older stamp is
+    dropped whole. openHop checked neither, so replaying an admin command with
+    the same timestamp and different attempt bits re-ran it -- packet dedup does
+    not catch that, because the bytes differ.
+    """
+    helper = _repeater_cli_helper()
+
+    await _deliver(helper, _TxtPacket("reboot", 1, sender_timestamp=100))
+    assert helper.cli.handle_command.call_count == 1
+
+    await _deliver(helper, _TxtPacket("reboot", 1, sender_timestamp=second_timestamp))
+    assert helper.cli.handle_command.call_count == 1, f"{label} timestamp re-ran the command"
+
+
+@pytest.mark.asyncio
+async def test_repeater_command_runs_again_for_a_newer_timestamp():
+    """The guard blocks replays, not legitimate repeat commands."""
+    helper = _repeater_cli_helper()
+
+    await _deliver(helper, _TxtPacket("reboot", 1, sender_timestamp=100))
+    await _deliver(helper, _TxtPacket("reboot", 1, sender_timestamp=101))
+
+    assert helper.cli.handle_command.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_room_post_is_not_stored_twice_for_a_retry():
+    """[fails pre-fix] firmware calls addPost only when `!is_retry`."""
+    helper, room = _room_helper(permissions=PERM_ACL_READ_WRITE)
+
+    await _deliver(helper, _TxtPacket("hello", 0, sender_timestamp=100), "room_server", "room")
+    await _deliver(helper, _TxtPacket("hello", 0, sender_timestamp=100), "room_server", "room")
+
+    assert room.add_post.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_handler_helpers_path_protocol_text.py
+++ b/tests/test_handler_helpers_path_protocol_text.py
@@ -1,3 +1,4 @@
+import asyncio
 import struct
 import time
 from types import SimpleNamespace
@@ -5,7 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openhop_core.node.handlers.result import HandlerResult
+from openhop_core.node.handlers.text import TXT_ACK_DELAY_MS
 from openhop_core.protocol import Identity, LocalIdentity
+from openhop_core.protocol.constants import PAYLOAD_TYPE_ACK
 from openhop_core.protocol.packet_builder import PacketBuilder
 
 from repeater.handler_helpers.acl import (
@@ -16,7 +19,7 @@ from repeater.handler_helpers.acl import (
 )
 from repeater.handler_helpers.path import PathHelper
 from repeater.handler_helpers.protocol_request import ProtocolRequestHelper
-from repeater.handler_helpers.text import TextHelper, _may_ack
+from repeater.handler_helpers.text import CORE_ACCEPTS_ACK_POLICY, TextHelper, _may_ack
 
 # ---------------------------------------------------------------------------
 # Real-crypto collision scaffolding (BUG-053 "try all local candidates").
@@ -602,7 +605,9 @@ async def test_room_dispatches_on_type_not_text(txt_type, is_command):
     "get status" ran as a command rather than being posted, and a CLI command
     whose text was not in the prefix list was published to the room.
 
-    Both cases use the *same* text, so only the type can decide.
+    Both cases use the *same* text, so only the type can decide. The text is
+    one `_is_cli_command` recognises, which is what makes the PLAIN row the
+    discriminator; the unrecognised direction is covered separately below.
     """
     helper, room = _room_helper()
 
@@ -615,6 +620,29 @@ async def test_room_dispatches_on_type_not_text(txt_type, is_command):
 
     assert room.cli.handle_command.called is is_command
     assert room.add_post.await_count == (0 if is_command else 1)
+
+
+@pytest.mark.asyncio
+async def test_room_runs_a_command_whose_text_is_not_a_known_prefix():
+    """[fails pre-fix] The other direction: an unrecognised CLI command still runs.
+
+    Deciding from the text published a command to the room whenever it was not
+    in `_is_cli_command`'s prefix list -- the room's members got to read what
+    the admin meant to run. Firmware routes every CLI_DATA/CLI_COMMAND from an
+    admin through handleCommand regardless of what it says
+    (simple_room_server::onPeerDataRecv).
+    """
+    helper, room = _room_helper()
+
+    await _deliver(
+        helper,
+        _TxtPacket("frobnicate", 1, sender_timestamp=100),
+        identity_type="room_server",
+        name="room",
+    )
+
+    room.cli.handle_command.assert_called_once()
+    room.add_post.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -659,7 +687,12 @@ async def test_repeater_command_is_not_run_twice(second_timestamp, label):
 
 @pytest.mark.asyncio
 async def test_repeater_command_runs_again_for_a_newer_timestamp():
-    """The guard blocks replays, not legitimate repeat commands."""
+    """A guard against over-blocking: a newer timestamp is fresh work.
+
+    Prerequisite rather than regression proof -- it passes with the guard
+    removed too. It is here so a future tightening of _accept_once cannot
+    quietly reject the legitimate case.
+    """
     helper = _repeater_cli_helper()
 
     await _deliver(helper, _TxtPacket("reboot", 1, sender_timestamp=100))
@@ -760,9 +793,72 @@ def test_may_ack_stays_quiet_for_an_unknown_client():
 
 
 def test_may_ack_keeps_acking_when_the_core_reports_no_type():
-    """An older core publishes no txt_type; do not go silent on that account."""
+    """An older core publishes no txt_type; do not go silent on that account.
+
+    Reached only through the compatibility fallback: a core old enough to omit
+    the type is also too old to install the policy, so this pins _may_ack's own
+    contract rather than a path the pair can take together.
+    """
     client = _FakeClient(pubkey=bytes([0x21]) + b"x" * 31, shared_secret=b"k" * 32, permissions=0)
     assert _may_ack("room_server", client, None, 100) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "permissions,expect_ack",
+    [
+        (PERM_ACL_READ_WRITE, True),  # a writer's post is stored and answered
+        (0, False),  # PERM_ACL_GUEST -- neither stored nor answered
+    ],
+)
+async def test_guest_plain_post_earns_no_ack_on_the_wire(permissions, expect_ack):
+    """[fails pre-fix] End to end: a guest's post produces nothing on the air.
+
+    This drives the whole MC-R4 seam with real crypto -- a genuinely encrypted
+    PLAIN DM, a real registered room identity, core's real TextMessageHandler,
+    the real ACL -- and watches the injector. Core schedules the ACK before
+    this helper's gates run, so without the policy the guest would see delivery
+    confirmed for a post that was then refused.
+
+    simple_room_server::onPeerDataRecv gives a guest neither storage nor ACK.
+    """
+    if not CORE_ACCEPTS_ACK_POLICY:
+        pytest.skip("installed openhop_core has no should_ack_fn hook")
+
+    server, sender = _distinct_identities(2)
+    acl = ACL()
+    client = ClientInfo(Identity(sender.get_public_key()), permissions=permissions)
+    client.shared_secret = Identity(sender.get_public_key()).calc_shared_secret(
+        server.get_private_key()
+    )
+    acl.clients[sender.get_public_key()] = client
+
+    injector = AsyncMock(return_value=True)
+    helper = TextHelper(
+        identity_manager=MagicMock(),
+        packet_injector=injector,
+        acl_dict={server.get_public_key()[0]: acl},
+    )
+    room = MagicMock()
+    room.add_post = AsyncMock(return_value=True)
+    room.cli = None
+    helper.register_identity("room", server, identity_type="room_server", radio_config={})
+    helper.room_servers[server.get_public_key()[0]] = room
+
+    packet, _crc = PacketBuilder.create_text_message(
+        _SendDest(server.get_public_key()), sender, "hello room", 0, "direct", None, 0
+    )
+    assert await helper.process_text_packet(packet) is True
+
+    # The ACK is scheduled on a delay; give it room to fire if it was going to.
+    await asyncio.sleep(TXT_ACK_DELAY_MS / 1000.0 + 0.2)
+
+    acked = any(
+        getattr(call.args[0], "get_payload_type", lambda: None)() == PAYLOAD_TYPE_ACK
+        for call in injector.await_args_list
+    )
+    assert acked is expect_ack
+    assert room.add_post.await_count == (1 if expect_ack else 0)
 
 
 def test_register_identity_survives_a_core_without_the_ack_hook():
@@ -811,7 +907,11 @@ def test_register_identity_hands_the_core_handler_an_ack_policy():
     )
     identity = _FakeId(bytes([0x33]) + b"x" * 31)
 
+    # Pin the capability flag: this test is about what the policy decides, not
+    # about which core happens to be importable, and indexing the kwarg would
+    # KeyError under an older one.
     with (
+        patch("repeater.handler_helpers.text.CORE_ACCEPTS_ACK_POLICY", True),
         patch("repeater.handler_helpers.text.TextMessageHandler") as tmh,
         patch("repeater.handler_helpers.text.MeshCLI", return_value=MagicMock()),
     ):

--- a/tests/test_handler_helpers_path_protocol_text.py
+++ b/tests/test_handler_helpers_path_protocol_text.py
@@ -458,6 +458,112 @@ def test_text_helper_cli_prefix_and_admin_permission_checks():
     assert helper._check_admin_permission_for_identity(0x23, 0x41) is False
 
 
+class _TxtPacket:
+    """A packet as the core TextMessageHandler leaves it: text + its type."""
+
+    def __init__(self, text: str, txt_type=None):
+        self.decrypted = {"text": text}
+        if txt_type is not None:
+            self.decrypted["txt_type"] = txt_type
+        self.payload = bytearray([0x41, 0x21])
+        self.mark_do_not_retransmit = MagicMock()
+
+
+def _repeater_cli_helper():
+    """A TextHelper wired as a repeater identity whose admin CLI is a stub."""
+    helper = TextHelper(identity_manager=MagicMock(), acl_dict={})
+    helper.repeater_hash = 0x41
+    helper.cli = MagicMock()
+    helper.cli.handle_command = MagicMock(return_value="ok")
+    helper.handlers = {0x41: {"name": "rep", "type": "repeater", "identity": MagicMock()}}
+    helper._resolve_sender_client = MagicMock(
+        return_value=_FakeClient(
+            pubkey=bytes([0x21]) + b"x" * 31,
+            shared_secret=b"k" * 32,
+            permissions=PERM_ACL_ADMIN,
+        )
+    )
+    helper._check_admin_permission_for_identity = MagicMock(return_value=True)
+    helper._send_cli_reply = AsyncMock()
+    return helper
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "txt_type,runs",
+    [
+        (0, True),  # PLAIN     -- legacy CLI, firmware still accepts it
+        (1, True),  # CLI_DATA  -- what every released client sends
+        (3, True),  # CLI_COMMAND -- the type firmware split out (2c0ace25)
+        (2, False),  # SIGNED_PLAIN -- a room post, never a command
+        (None, True),  # no type reported (older core): behave as before
+    ],
+)
+async def test_text_helper_runs_cli_only_for_server_text_types(txt_type, runs):
+    """[fails pre-fix for SIGNED_PLAIN] The text type gates the CLI, not the text.
+
+    simple_repeater::onPeerDataRecv opens its TXT_MSG branch by rejecting any
+    flags outside {PLAIN, CLI_DATA, CLI_COMMAND}. openHop dispatched purely on
+    whether the text looked like a command, so a SIGNED_PLAIN -- a room post,
+    whose 4-byte author prefix the core handler has already stripped, leaving
+    bare text -- ran as an admin CLI command whenever it happened to start with
+    a command prefix.
+
+    ``txt_type is None`` is a core too old to report it; that must keep working
+    rather than silently dropping every message.
+    """
+    helper = _repeater_cli_helper()
+    packet = _TxtPacket("get status", txt_type)
+
+    await helper._on_message_received(
+        identity_name="rep",
+        identity_type="repeater",
+        packet=packet,
+        dest_hash=0x41,
+        src_hash=0x21,
+    )
+
+    assert helper.cli.handle_command.called is runs
+    assert helper._send_cli_reply.await_count == (1 if runs else 0)
+
+
+@pytest.mark.asyncio
+async def test_text_helper_signed_plain_is_not_stored_as_a_room_post():
+    """A SIGNED_PLAIN never reaches the room server either.
+
+    simple_room_server::onPeerDataRecv carries the same filter as the repeater;
+    only PLAIN becomes a post there. openHop stored whatever arrived.
+    """
+    helper = TextHelper(identity_manager=MagicMock(), acl_dict={})
+    room = MagicMock()
+    room.add_post = AsyncMock(return_value=True)
+    room.cli = None
+    helper.room_servers = {0x41: room}
+    helper.handlers = {0x41: {"name": "room", "type": "room_server", "identity": MagicMock()}}
+    helper._resolve_sender_client = MagicMock(
+        return_value=_FakeClient(pubkey=bytes([0x21]) + b"x" * 31, shared_secret=b"k" * 32)
+    )
+
+    await helper._on_message_received(
+        identity_name="room",
+        identity_type="room_server",
+        packet=_TxtPacket("hello room", 2),
+        dest_hash=0x41,
+        src_hash=0x21,
+    )
+    room.add_post.assert_not_awaited()
+
+    # ...while a plain post still lands.
+    await helper._on_message_received(
+        identity_name="room",
+        identity_type="room_server",
+        packet=_TxtPacket("hello room", 0),
+        dest_hash=0x41,
+        src_hash=0x21,
+    )
+    room.add_post.assert_awaited_once()
+
+
 @pytest.mark.asyncio
 async def test_text_helper_process_text_packet_routes_or_forwards():
     helper = TextHelper(identity_manager=MagicMock(), acl_dict={})

--- a/tests/test_handler_helpers_path_protocol_text.py
+++ b/tests/test_handler_helpers_path_protocol_text.py
@@ -16,7 +16,7 @@ from repeater.handler_helpers.acl import (
 )
 from repeater.handler_helpers.path import PathHelper
 from repeater.handler_helpers.protocol_request import ProtocolRequestHelper
-from repeater.handler_helpers.text import TextHelper
+from repeater.handler_helpers.text import TextHelper, _may_ack
 
 # ---------------------------------------------------------------------------
 # Real-crypto collision scaffolding (BUG-053 "try all local candidates").
@@ -720,6 +720,108 @@ async def test_text_helper_room_post_denies_guests(permissions, posts):
     )
 
     assert room.add_post.await_count == (1 if posts else 0)
+
+
+@pytest.mark.parametrize(
+    "identity_type,permissions,txt_type,timestamp,allowed,why",
+    [
+        ("repeater", PERM_ACL_ADMIN, 0, 101, True, "PLAIN from an admin is the legacy CLI"),
+        ("repeater", PERM_ACL_READ_WRITE, 0, 101, False, "the branch is gated on isAdmin()"),
+        ("repeater", PERM_ACL_ADMIN, 1, 101, False, "no ACK for a CLI type"),
+        ("repeater", PERM_ACL_ADMIN, 3, 101, False, "no ACK for a CLI type"),
+        ("repeater", PERM_ACL_ADMIN, 2, 101, False, "SIGNED_PLAIN is not an accepted type"),
+        ("repeater", PERM_ACL_ADMIN, 0, 99, False, "older stamp: the branch is skipped"),
+        ("repeater", PERM_ACL_ADMIN, 0, 100, True, "equal stamp is a retry, still ACKed"),
+        ("room_server", PERM_ACL_READ_WRITE, 0, 101, True, "a writer's post is ACKed"),
+        ("room_server", 0, 0, 101, False, "a guest gets neither post nor ACK"),
+        ("room_server", PERM_ACL_ADMIN, 1, 101, False, "no ACK for a CLI type"),
+    ],
+)
+def test_may_ack_matches_firmware(identity_type, permissions, txt_type, timestamp, allowed, why):
+    """A server ACKs only what it would accept, and decides before answering.
+
+    simple_repeater builds an ACK only under `if (flags == TXT_TYPE_PLAIN)`,
+    inside a branch already gated on `client->isAdmin()`. simple_room_server
+    sets send_ack only on the non-guest PLAIN path. Neither answers a CLI type,
+    an unsupported type, or a replayed timestamp -- but both still answer a
+    retry, because firmware suppresses the work, not the reply.
+    """
+    client = _FakeClient(
+        pubkey=bytes([0x21]) + b"x" * 31, shared_secret=b"k" * 32, permissions=permissions
+    )
+    client.last_timestamp = 100
+
+    assert _may_ack(identity_type, client, txt_type, timestamp) is allowed, why
+
+
+def test_may_ack_stays_quiet_for_an_unknown_client():
+    """Firmware only reaches onPeerDataRecv for a client its ACL matched."""
+    assert _may_ack("repeater", None, 0, 100) is False
+
+
+def test_may_ack_keeps_acking_when_the_core_reports_no_type():
+    """An older core publishes no txt_type; do not go silent on that account."""
+    client = _FakeClient(pubkey=bytes([0x21]) + b"x" * 31, shared_secret=b"k" * 32, permissions=0)
+    assert _may_ack("room_server", client, None, 100) is True
+
+
+def test_register_identity_survives_a_core_without_the_ack_hook():
+    """[fails pre-fix] An older core must not take the node off the air.
+
+    `pyproject.toml` tracks `openhop_core@dev` with no version floor, so running
+    against a core that predates should_ack_fn is an ordinary state. Passing the
+    argument regardless raises TypeError out of register_identity, which leaves
+    the node with no text handler at all -- a far worse outcome than an ACK it
+    should have withheld.
+    """
+    acl = _FakeACL([_FakeClient(pubkey=bytes([0x35]) + b"x" * 31, shared_secret=b"k" * 32)])
+    helper = TextHelper(
+        identity_manager=MagicMock(), packet_injector=AsyncMock(), acl_dict={0x35: acl}
+    )
+    identity = _FakeId(bytes([0x35]) + b"x" * 31)
+
+    with (
+        patch("repeater.handler_helpers.text.CORE_ACCEPTS_ACK_POLICY", False),
+        patch("repeater.handler_helpers.text.TextMessageHandler") as tmh,
+        patch("repeater.handler_helpers.text.MeshCLI", return_value=MagicMock()),
+    ):
+        helper.register_identity("rep", identity, identity_type="repeater", radio_config={})
+
+    assert "should_ack_fn" not in tmh.call_args.kwargs
+    assert 0x35 in helper.handlers
+
+
+def test_register_identity_hands_the_core_handler_an_ack_policy():
+    """The policy has to reach the handler, or none of the above applies.
+
+    Core decides the ACK before the repeater's gates run, so this seam is the
+    only place a server's rule can be applied in time.
+    """
+    acl = _FakeACL(
+        [
+            _FakeClient(
+                pubkey=bytes([0x33]) + b"x" * 31,
+                shared_secret=b"k" * 32,
+                permissions=PERM_ACL_ADMIN,
+            )
+        ]
+    )
+    helper = TextHelper(
+        identity_manager=MagicMock(), packet_injector=AsyncMock(), acl_dict={0x33: acl}
+    )
+    identity = _FakeId(bytes([0x33]) + b"x" * 31)
+
+    with (
+        patch("repeater.handler_helpers.text.TextMessageHandler") as tmh,
+        patch("repeater.handler_helpers.text.MeshCLI", return_value=MagicMock()),
+    ):
+        helper.register_identity("rep", identity, identity_type="repeater", radio_config={})
+
+    policy = tmh.call_args.kwargs["should_ack_fn"]
+    admin_key = bytes([0x33]) + b"x" * 31
+    assert policy(admin_key, 0, 100) is True  # PLAIN from the admin
+    assert policy(admin_key, 1, 100) is False  # CLI_DATA earns no ACK
+    assert policy(bytes([0x44]) + b"x" * 31, 0, 100) is False  # not a client here
 
 
 @pytest.mark.asyncio

--- a/tests/test_handler_helpers_path_protocol_text.py
+++ b/tests/test_handler_helpers_path_protocol_text.py
@@ -565,6 +565,49 @@ async def test_text_helper_signed_plain_is_not_stored_as_a_room_post():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "permissions,posts",
+    [
+        (PERM_ACL_ADMIN, True),
+        (PERM_ACL_READ_WRITE, True),
+        (0, False),  # PERM_ACL_GUEST -- read the room, do not write to it
+    ],
+)
+async def test_text_helper_room_post_denies_guests(permissions, posts):
+    """[fails pre-fix] A guest may read the room but not post to it.
+
+    simple_room_server::onPeerDataRecv takes the
+    `(client->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST` branch for a
+    PLAIN message and stores nothing. openHop called add_post for anyone who
+    authenticated, so the guest password was enough to write to the room --
+    add_post enforces a length cap and a rate limit, but no role.
+    """
+    helper = TextHelper(identity_manager=MagicMock(), acl_dict={})
+    room = MagicMock()
+    room.add_post = AsyncMock(return_value=True)
+    room.cli = None
+    helper.room_servers = {0x41: room}
+    helper.handlers = {0x41: {"name": "room", "type": "room_server", "identity": MagicMock()}}
+    helper._resolve_sender_client = MagicMock(
+        return_value=_FakeClient(
+            pubkey=bytes([0x21]) + b"x" * 31,
+            shared_secret=b"k" * 32,
+            permissions=permissions,
+        )
+    )
+
+    await helper._on_message_received(
+        identity_name="room",
+        identity_type="room_server",
+        packet=_TxtPacket("hello room", 0),
+        dest_hash=0x41,
+        src_hash=0x21,
+    )
+
+    assert room.add_post.await_count == (1 if posts else 0)
+
+
+@pytest.mark.asyncio
 async def test_text_helper_process_text_packet_routes_or_forwards():
     helper = TextHelper(identity_manager=MagicMock(), acl_dict={})
 

--- a/tests/test_handler_helpers_room_server.py
+++ b/tests/test_handler_helpers_room_server.py
@@ -368,6 +368,49 @@ async def test_room_server_push_post_to_client_clamps_oversized_legacy_stored_te
 
 
 @pytest.mark.asyncio
+async def test_room_server_push_ends_the_text_at_an_embedded_nul():
+    """[fails pre-fix] A stored post with an interior NUL is cut where firmware cuts it.
+
+    pushPostToClient sizes the body with `strlen(post.text)`, for the payload
+    and the expected ACK alike. The web API will store "a\0b", so pushing it
+    whole sends text the receiver cannot see -- it stops at the NUL -- and,
+    worse, hashes the pending ACK over a span the receiver never reproduces.
+    The push would then never be acknowledged and would retry into the
+    failure backoff.
+    """
+    db = _FakeDB()
+    db.get_client_sync.return_value = {"push_failures": 0}
+    injector = AsyncMock(return_value=True)
+    rs = _make_room_server(db=db, injector=injector)
+    rs.global_limiter = SimpleNamespace(acquire=AsyncMock(), release=MagicMock())
+    rs._handle_ack_received = AsyncMock()
+
+    client = _FakeClient(pubkey=b"E" * 32, out_path=b"\xaa\xbb", out_path_len=2)
+    post = {
+        "author_pubkey": (b"F" * 32).hex(),
+        "message_text": "a\x00b",
+        "post_timestamp": 1234.5,
+    }
+
+    packet = SimpleNamespace(path=bytearray(), path_len=0)
+    with (
+        patch(
+            "repeater.handler_helpers.room_server.CryptoUtils.sha256",
+            return_value=b"\x01\x02\x03\x04abcd",
+        ),
+        patch(
+            "repeater.handler_helpers.room_server.PacketBuilder.create_datagram",
+            return_value=packet,
+        ) as create_datagram,
+    ):
+        ok = await rs.push_post_to_client(client, post)
+
+    assert ok is True
+    # Prefix is timestamp(4) + flags(1) + author_prefix(4) = 9 bytes.
+    assert create_datagram.call_args.kwargs["plaintext"][9:] == b"a"
+
+
+@pytest.mark.asyncio
 async def test_room_server_push_expected_ack_matches_firmware_signed_ack():
     """The pending ACK CRC must match what a signed-plain receiver sends back.
 

--- a/tests/test_tx_lock.py
+++ b/tests/test_tx_lock.py
@@ -17,6 +17,7 @@ or:
 import asyncio
 import time
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 # ---------------------------------------------------------------------------
@@ -282,6 +283,211 @@ class TestTxLockSerialisation(unittest.IsolatedAsyncioTestCase):
         _, kwargs = h.dispatcher.send_packet.call_args
         self.assertEqual(kwargs.get("radio_id"), "link")
         self.assertEqual(kwargs.get("wait_for_ack"), False)
+
+
+class TestLocalTxRadioLinkWait(unittest.IsolatedAsyncioTestCase):
+    """A local TX waits out a radio-link outage instead of spending its retry on it."""
+
+    async def test_waits_for_a_dropped_link_then_transmits(self):
+        """A KISS modem that drops off USB re-handshakes in ~2s; hold the TX for it."""
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 2.0
+        pkt = _make_packet()
+
+        h.dispatcher.radio.is_connected = False
+        h.dispatcher.radio.is_degraded = True
+
+        async def restore_link():
+            await asyncio.sleep(0.25)
+            h.dispatcher.radio.is_connected = True
+            h.dispatcher.radio.is_degraded = False
+
+        asyncio.create_task(restore_link())
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(pkt, delay=0.0, airtime_ms=0, local_transmission=True)
+        result = await task
+        elapsed = time.monotonic() - started
+
+        self.assertTrue(result)
+        self.assertEqual(h.dispatcher.send_packet.call_count, 1)  # no attempt wasted
+        self.assertGreaterEqual(elapsed, 0.25)  # it really waited
+
+    async def test_gives_up_when_the_link_never_returns(self):
+        """A wedged link is bounded, not waited on forever, and never transmitted to."""
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 0.3
+        pkt = _make_packet()
+
+        h.dispatcher.radio.is_connected = False
+        h.dispatcher.radio.is_degraded = True
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(pkt, delay=0.0, airtime_ms=0, local_transmission=True)
+        result = await task
+        elapsed = time.monotonic() - started
+
+        self.assertFalse(result)
+        h.dispatcher.send_packet.assert_not_called()
+        self.assertLess(elapsed, 2.0)
+
+    async def test_radio_without_link_state_is_not_delayed(self):
+        """Radios that track no link state (direct SPI) must keep their timing."""
+        h = _make_handler()  # MagicMock radio: is_connected/is_degraded are mocks
+        pkt = _make_packet()
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(pkt, delay=0.0, airtime_ms=0, local_transmission=True)
+        result = await task
+        elapsed = time.monotonic() - started
+
+        self.assertTrue(result)
+        self.assertLess(elapsed, 0.2)
+
+    async def test_relayed_packet_does_not_wait(self):
+        """Only local TX waits; a repeat held back that long is worse than dropped."""
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 5.0
+        pkt = _make_packet()
+
+        h.dispatcher.radio.is_connected = False
+        h.dispatcher.radio.is_degraded = True
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(pkt, delay=0.0, airtime_ms=0, local_transmission=False)
+        await task
+        elapsed = time.monotonic() - started
+
+        h.dispatcher.send_packet.assert_called_once()
+        self.assertLess(elapsed, 0.2)
+
+    async def test_waits_for_the_selected_radio_not_the_default(self):
+        """With a fabric, link state must follow preferred_tx_radio_id.
+
+        Attribute access on a FabricRadio passes through to its default endpoint, so
+        reading state off it would suppress a healthy selected radio (or wave through
+        a dead one) whenever the default disagrees.
+        """
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 0.3
+        pkt = _make_packet()
+
+        up = SimpleNamespace(is_connected=True, is_degraded=False)
+        down = SimpleNamespace(is_connected=False, is_degraded=True)
+        endpoints = {"a": up, "b": down}
+        fabric = MagicMock()
+        fabric.radios = endpoints
+        fabric.get_radio = lambda rid: endpoints[rid]
+        h.dispatcher.radio.fabric = fabric
+        # The default endpoint is down; the selected one is not.
+        h.dispatcher.radio.is_connected = False
+        h.dispatcher.radio.is_degraded = True
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(
+            pkt, delay=0.0, airtime_ms=0, local_transmission=True, preferred_tx_radio_id="a"
+        )
+        result = await task
+        elapsed = time.monotonic() - started
+
+        self.assertTrue(result)
+        h.dispatcher.send_packet.assert_called_once()
+        self.assertLess(elapsed, 0.2)  # never waited on the default radio
+
+    async def test_waits_when_the_selected_radio_is_the_down_one(self):
+        """The converse: a down selected radio is waited for, default health aside."""
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 0.3
+        pkt = _make_packet()
+
+        up = SimpleNamespace(is_connected=True, is_degraded=False)
+        down = SimpleNamespace(is_connected=False, is_degraded=True)
+        endpoints = {"a": up, "b": down}
+        fabric = MagicMock()
+        fabric.radios = endpoints
+        fabric.get_radio = lambda rid: endpoints[rid]
+        h.dispatcher.radio.fabric = fabric
+        h.dispatcher.radio.is_connected = True  # default is healthy
+
+        task = await h.schedule_retransmit(
+            pkt, delay=0.0, airtime_ms=0, local_transmission=True, preferred_tx_radio_id="b"
+        )
+        result = await task
+
+        self.assertFalse(result)
+        h.dispatcher.send_packet.assert_not_called()
+
+    async def test_multi_radio_fabric_without_a_target_does_not_wait(self):
+        """The fabric picks at send time, so there is nothing to inspect: fail open."""
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 5.0
+        pkt = _make_packet()
+
+        endpoints = {
+            "a": SimpleNamespace(is_connected=False, is_degraded=True),
+            "b": SimpleNamespace(is_connected=False, is_degraded=True),
+        }
+        fabric = MagicMock()
+        fabric.radios = endpoints
+        h.dispatcher.radio.fabric = fabric
+        h.dispatcher.radio.is_connected = False
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(pkt, delay=0.0, airtime_ms=0, local_transmission=True)
+        await task
+        elapsed = time.monotonic() - started
+
+        h.dispatcher.send_packet.assert_called_once()
+        self.assertLess(elapsed, 0.2)
+
+    async def test_retry_waits_when_the_link_drops_after_the_first_attempt(self):
+        """The real sequence: send fails, the link goes, it returns, the retry lands."""
+        h = _make_handler()
+        h.config["delays"]["local_tx_link_wait_seconds"] = 2.0
+        pkt = _make_packet()
+
+        async def restore_link():
+            await asyncio.sleep(0.25)
+            h.dispatcher.radio.is_connected = True
+            h.dispatcher.radio.is_degraded = False
+
+        attempts = []
+
+        async def send_side_effect(*args, **kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                # The modem falls off the bus as the first attempt fails.
+                h.dispatcher.radio.is_connected = False
+                h.dispatcher.radio.is_degraded = True
+                asyncio.create_task(restore_link())
+                return False
+            return True
+
+        h.dispatcher.send_packet.side_effect = send_side_effect
+
+        started = time.monotonic()
+        task = await h.schedule_retransmit(pkt, delay=0.0, airtime_ms=0, local_transmission=True)
+        result = await task
+        elapsed = time.monotonic() - started
+
+        self.assertTrue(result)
+        self.assertEqual(len(attempts), 2)
+        self.assertGreaterEqual(elapsed, 0.25)  # waited for the link
+        self.assertLess(elapsed, 1.0)  # and skipped the flat 1s backoff
+
+    def test_configured_wait_must_be_finite_and_bounded(self):
+        """An infinite or absurd ceiling would hold the companion's command open."""
+        h = _make_handler()
+        for value, expected in (
+            (float("inf"), h.DEFAULT_LOCAL_TX_LINK_WAIT_S),
+            (float("nan"), h.DEFAULT_LOCAL_TX_LINK_WAIT_S),
+            ("not a number", h.DEFAULT_LOCAL_TX_LINK_WAIT_S),
+            (1e9, h.MAX_LOCAL_TX_LINK_WAIT_S),
+            (-5, 0.0),
+            (2.5, 2.5),
+        ):
+            h.config["delays"]["local_tx_link_wait_seconds"] = value
+            self.assertEqual(h._local_tx_link_wait_s(), expected, msg=f"for {value!r}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Match firmware's TXT_MSG gates: text type, role, replay, and the ACK

Base: `dev` · Branch: `fix/cli-text-type-filter`

Downstream half of the core parity work merged in openhop-dev/openhop_core#135.
Core now publishes `txt_type` and `sender_timestamp` on `packet.decrypted` and
accepts a `should_ack_fn` on `TextMessageHandler`; this PR uses both to bring
`TextHelper` in line with `simple_repeater::onPeerDataRecv` and
`simple_room_server::onPeerDataRecv`.

## What firmware does, and what we did instead

Both firmware servers open the TXT_MSG branch the same way:

```cpp
if (!(flags == TXT_TYPE_PLAIN || flags == TXT_TYPE_CLI_DATA || flags == TXT_TYPE_CLI_COMMAND)) {
  MESH_DEBUG_PRINTLN("unsupported text type received: flags=%02x", flags);
} else if (sender_timestamp >= client->last_timestamp) {
  bool is_retry = (sender_timestamp == client->last_timestamp);
  client->last_timestamp = sender_timestamp;
  ...
```

openHop reached none of that. It decided what a message was purely from
whether the text looked like a command, and never looked at the timestamp.

**No text-type gate.** A `SIGNED_PLAIN` — a room post, whose 4-byte author
prefix the core handler has already split off, leaving bare text — ran as an
admin CLI command whenever it happened to start with a command prefix, and was
stored as a post on a room server that firmware would have dropped.

**Dispatch by text, not by type.** `simple_room_server` routes
`CLI_DATA`/`CLI_COMMAND` to the admin CLI and turns `PLAIN` into a post;
`simple_repeater` has no chat function and runs every accepted type through
`handleCommand` with no text test at all. Asking `_is_cli_command(text)` for
both got both wrong: a `PLAIN` "set ..." ran as a command instead of being
posted, a command whose text was not in the prefix list was published to the
room, and an admin's mistyped repeater command vanished silently instead of
being answered.

**No replay guard.** Replaying an admin command with the same timestamp and
different attempt bits re-executed it — packet dedup does not catch that,
because the bytes differ.

**Guests could post.** `simple_room_server` takes the
`(client->permissions & PERM_ACL_ROLE_MASK) == PERM_ACL_GUEST` branch for a
`PLAIN` message and stores nothing. openHop called `add_post` for anyone who
authenticated, so knowing the guest password was enough to write to a room:
`add_post` caps length and rate-limits per client, but never looks at the role.

**The ACK went out before any of these gates.** The core text handler answers
by `BaseChatMesh`'s rule — plain and signed text, never a CLI type — and it
runs before this helper. So a signed post, a non-admin command or a guest's
post was acknowledged and only then thrown away: the sender saw delivery
confirmed for a message that went nowhere.

## Changes

- `SERVER_TXT_TYPES` gate on `{PLAIN, CLI_DATA, CLI_COMMAND}`. `CLI_COMMAND`
  (3) is in the set because firmware split it out of `CLI_DATA`
  (MeshCore `2c0ace25`); `CLI_DATA` stays because that is what every released
  client still sends.
- `_accept_once()` is firmware's replay guard: older timestamp dropped, equal
  treated as a retry that is accepted but re-runs nothing, watermark advanced
  either way.
- Dispatch on `txt_type` for both identity types, matching each server.
- Guests are refused the room, and a retried post is not stored twice.
- `_may_ack()` is firmware's ACK rule for a server, handed to core as
  `should_ack_fn` at `register_identity`, so nothing this server refuses is
  ever acknowledged. It is read-only and leaves no state behind.
- `pushPostToClient` sizes its body with `strlen(post.text)`; our hand-rolled
  builder in `room_server.py` now ends a pushed post's text at an embedded NUL
  too. Pushing `"a\0b"` whole sent text the receiver cannot see and hashed the
  pending ACK over a span it never reproduces, so the push was never
  acknowledged and retried into the failure backoff.

Also on this branch, not a parity fix:

- **`fix(engine)`** — a local transmit retried after a flat 1s backoff. When
  the failure was the link itself (a KISS modem that dropped off USB and is
  re-enumerating, ~2s to come back and re-handshake) that retry landed inside
  the outage and failed immediately, turning one modem hiccup into a failed
  message while the companion client was still waiting. A dropped link is now
  waited out instead, polled at 100ms and bounded by
  `delays.local_tx_link_wait_seconds` (default 5s, capped at 30s, non-finite
  rejected). Link state is read from the radio the send will actually use —
  attribute access on a `FabricRadio` passes through to its *default* endpoint,
  so a send carrying `preferred_tx_radio_id` would otherwise be judged by the
  wrong radio. Relayed packets never wait. Radios that track no link state
  keep their exact timing.

## Compatibility

Every new gate reads from `packet.decrypted`. A core too old to publish
`txt_type`/`sender_timestamp` leaves the gate open and falls back to the
previous text-prefix behaviour, logging a warning rather than dropping every
message. `should_ack_fn` is passed only when `TextMessageHandler.__init__`
accepts it — passing it to an older core raises `TypeError` out of
`register_identity`, which would leave the node with no text handler at all.
`pyproject.toml` tracks `openhop_core@dev` with no version floor, so an older
core is an ordinary state to be in; in it the ACK goes back to being sent,
availability over the invariant.

## Known deviation

`_accept_once` advances `client.last_timestamp` before the admin check, while
`simple_repeater` gates its whole TXT_MSG branch on `client->isAdmin()` and so
never advances the watermark for a non-admin. The effect is confined to that
client's own watermark, and a non-admin can never run a command regardless.

`_may_ack` predicts *eligibility*, not the outcome: a post that clears the role
and replay checks and is then refused by openHop's own rate limit or a database
error is still ACKed. Those refusals have no firmware counterpart, so closing
that gap needs the store result fed back to an ACK core has already scheduled.

## Testing

`1608 passed` on this branch. New coverage includes an end-to-end MC-R4 case: a
genuinely encrypted guest `PLAIN` through a real registered room identity,
watching the injector for an ACK that must not appear.
