### PR TITLE
ci: reformat two files ruff 0.15.14 would rewrite

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -3884,16 +3884,13 @@ class SQLiteHandler:
                         if t in self._ADVERT_TYPE_BY_API
                     }
                     stored = sorted(
-                        key
-                        for key, adv in self._ADVERT_TYPE_BY_STORED.items()
-                        if adv in wanted
+                        key for key, adv in self._ADVERT_TYPE_BY_STORED.items() if adv in wanted
                     )
                     if not stored:
                         return 0
                     placeholders = ",".join("?" * len(stored))
                     query += (
-                        " AND LOWER(REPLACE(TRIM(contact_type), ' ', '_')) "
-                        f"IN ({placeholders})"
+                        f" AND LOWER(REPLACE(TRIM(contact_type), ' ', '_')) IN ({placeholders})"
                     )
                     params.extend(stored)
                 if hours is not None:

--- a/tests/test_companion_import_repeater_contacts.py
+++ b/tests/test_companion_import_repeater_contacts.py
@@ -18,6 +18,7 @@ than 1 even on an unfiltered import.
 
 Both derived the mapping independently; they now share one table.
 """
+
 import os
 import shutil
 import sqlite3


### PR DESCRIPTION
`pre-commit run --all-files` fails on `dev` at the `ruff-format` hook, so every open pull request is red on a check unrelated to its own diff. Both files arrived with 72da7ee (pr-436) formatted by an earlier ruff. Purely cosmetic — exactly what `ruff format` produces.