### PR TITLE
Add Philadelphia preset

### DIFF
--- a/radio-presets.json
+++ b/radio-presets.json
@@ -145,13 +145,21 @@
                     "bandwidth": "250",
                     "coding_rate": "5"
                 },
-                  {
+                {
                     "title": "USA (Southern California)",
                     "description": "927.875MHz / SF7 / BW62.5 / CR7",
                     "frequency": "927.875",
                     "spreading_factor": "7",
                     "bandwidth": "62.5",
                     "coding_rate": "7"
+                },
+                {
+                    "title": "USA (Philadelphia Metro)",
+                    "description": "902.250MHz / SF11 / BW500 / CR5",
+                    "frequency": "902.250",
+                    "spreading_factor": "11",
+                    "bandwidth": "500",
+                    "coding_rate": "5"
                 },
                 {
                     "title": "Vietnam",


### PR DESCRIPTION
This PR adds the Philadelphia area preset to the list of existing presets. Philadlephia moved announced this change ~1w ago here: https://phillymesh.net/2026/09/02/fcc-regulations/

