### PR TITLE
Remove Philadelphia Metro radio preset

### DIFF
--- a/radio-presets.json
+++ b/radio-presets.json
@@ -154,14 +154,6 @@
                     "coding_rate": "7"
                 },
                 {
-                    "title": "USA (Philadelphia Metro)",
-                    "description": "902.250MHz / SF11 / BW500 / CR5",
-                    "frequency": "902.250",
-                    "spreading_factor": "11",
-                    "bandwidth": "500",
-                    "coding_rate": "5"
-                },
-                {
                     "title": "Vietnam",
                     "description": "920.250MHz / SF11 / BW250 / CR5",
                     "frequency": "920.250",


### PR DESCRIPTION
## Summary
openHop will follow the radio presets included in MeshCore firmware. As part of that policy, the USA (Philadelphia Metro) preset (902.250 MHz / SF11 / BW500 / CR5) will be removed from the bundled radio preset list.

This PR removes only that entry from `radio-presets.json`. All other presets remain unchanged. It does not implement automatic preset synchronization or change existing saved radio settings.

---

We recognize that this decision goes against the direction taken in the [blog post.](https://phillymesh.net/2026/09/02/fcc-regulations/) However, we consider the attacks on already-established meshes here in the US uncalled for.

Switching from the established 62.5 kHz bandwidth to 500 kHz would prevent users from communicating directly with nodes that remain on the existing settings. An uncoordinated switch would split users from already-established networks and create connectivity issues within the mesh. The Philadelphia Metro preset also changes the frequency and spreading factor relative to the USA/Canada recommended preset, so this is not a drop-in compatible change.

Until the FCC issues an official statement on this matter or MeshCore changes its presets, openHop will stick with the defaults included in MeshCore firmware, plus the "USA (Southern California)" preset. The "USA (Philadelphia Metro)" preset will therefore be removed from our bundled list.

## Verification
- Parsed the updated JSON successfully.
- Compared the complete preset data against the base branch and verified that exactly the requested entry was removed, with all other data unchanged.
- `git diff --check` passed.