### PR TITLE
feat(config): pass lna_gain_db through to SX1262Radio

### DIFF
--- a/repeater/config.py
+++ b/repeater/config.py
@@ -589,6 +589,8 @@ def get_radio_for_board(board_config: dict):
             combined_config["use_gpiod_backend"] = spi_config["use_gpiod_backend"]
         if "radio_timing_delay" in spi_config:
             combined_config["radio_timing_delay"] = float(spi_config["radio_timing_delay"])
+        if "lna_gain_db" in spi_config:
+            combined_config["lna_gain_db"] = float(spi_config["lna_gain_db"])
 
         # Always construct a fresh instance so multi-radio configs do not
         # share/reuse a singleton SX1262 handle.


### PR DESCRIPTION
## Summary

Lets `sx1262.lna_gain_db` in `config.yaml` reach `SX1262Radio`. Companion to
openhop-dev/openhop_core#143, which adds the argument and does the actual compensation.

## Why

Boards built around modules such as the Ebyte E22P, or front ends like the SKY66122, put an LNA
between the antenna and the SX1262. The chip cannot know it is there, so every RSSI it reports
is inflated by that LNA's gain, including the idle noise floor. Without compensation the
reported noise floor looks alarming and cross-hardware comparisons are silently wrong.

Measured on a MeshSmith PiMesh-1W V2 (E22P), swapped in for a Heltec V3 on the same node,
antenna and mast: a uniform **+14.5 dB** offset across six independent distant sources. The
reported noise floor moved from -109 to -95 dBm with no actual change in reception. With
compensation enabled it reads -112, and the weak-signal population that appeared to have
vanished is visibly back (73 of 101 receptions below -100 dBm over a 7 minute window).

## Change

Two lines, following the established optional-parameter convention immediately above it
alongside `gpio_chip`, `use_gpiod_backend` and `radio_timing_delay`:

```python
if "lna_gain_db" in spi_config:
    combined_config["lna_gain_db"] = float(spi_config["lna_gain_db"])
```

Only forwarded when present in the config, so older `openhop_core` versions that do not accept
the argument are unaffected. Like its three siblings it is an untested passthrough; the
behaviour it enables is covered by tests in the core PR.

## Usage

```yaml
sx1262:
  lna_gain_db: 14.5   # external front-end LNA gain, dB
```

## Note on presets

I have deliberately not added values to `radio-settings.json` here. My +14.5 dB is one
measurement on one PiMesh-1W V2 unit, and per-board defaults should come from maintainers or
the vendors rather than a single sample. The presets that would want a value eventually are the
E22P-based ones: PiMesh-1W V1/V2, ZebraHat-1W, NebraDuo-E22P-1W and the UltraPeater E22P
variants.
