### PR TITLE
fix(companion): remove a synced message on the client's next command, not on read

### DIFF
--- a/repeater/companion/frame_server.py
+++ b/repeater/companion/frame_server.py
@@ -13,7 +13,7 @@ import logging
 import shutil
 from typing import Callable, Optional
 
-from openhop_core.companion.constants import RESP_CODE_NO_MORE_MESSAGES
+from openhop_core.companion.constants import MAX_PAYLOAD_SIZE, RESP_CODE_NO_MORE_MESSAGES
 from openhop_core.companion.frame_server import CompanionFrameServer as _BaseFrameServer
 from openhop_core.companion.models import QueuedMessage
 
@@ -58,6 +58,10 @@ class CompanionFrameServer(_BaseFrameServer):
         self.sqlite_handler = sqlite_handler
         self.batt_getter = batt_getter
         self.storage_dir = storage_dir
+        # (client writer, SQLite id) of the message handed to the client by the
+        # last SYNC_NEXT_MESSAGE. It is deleted when that client's next command
+        # arrives; a client that drops first is sent it again.
+        self._pending_delete: Optional[tuple[asyncio.StreamWriter, int]] = None
 
     def _get_batt_and_storage(self) -> tuple[int, int, int]:
         """Report battery millivolts and storage usage to companion clients.
@@ -160,8 +164,10 @@ class CompanionFrameServer(_BaseFrameServer):
         if not self.sqlite_handler:
             return None
         msg_dict = self.sqlite_handler.companion_pop_message(self.companion_hash)
-        if not msg_dict:
-            return None
+        return self._queued_message_from_row(msg_dict) if msg_dict else None
+
+    @staticmethod
+    def _queued_message_from_row(msg_dict: dict) -> QueuedMessage:
         sender_prefix = msg_dict.get("sender_prefix", b"")
         if isinstance(sender_prefix, str):
             sender_prefix = bytes.fromhex(sender_prefix) if sender_prefix else b""
@@ -184,11 +190,50 @@ class CompanionFrameServer(_BaseFrameServer):
     # Non-blocking command overrides (keep event loop responsive)
     # -----------------------------------------------------------------
 
+    async def _handle_cmd(self, payload: bytes) -> None:
+        """Any further command from the client is the receipt for the last synced message."""
+        pending, self._pending_delete = self._pending_delete, None
+        if pending is not None and pending[0] is getattr(self, "_client_writer", None):
+            await asyncio.to_thread(
+                self.sqlite_handler.companion_delete_message, self.companion_hash, pending[1]
+            )
+        await super()._handle_cmd(payload)
+
     async def _cmd_sync_next_message(self, data: bytes) -> None:
-        """Sync next message; run persistence read in thread so SQLite does not block."""
+        """Sync next message; run persistence read in thread so SQLite does not block.
+
+        A persisted message is not removed when it is read. It is removed when
+        the client's next command arrives (:meth:`_handle_cmd`), so a client
+        that drops between the read and the receipt is sent it again.
+        """
         msg = self.bridge.sync_next_message()
-        if msg is None:
-            msg = await asyncio.to_thread(self._sync_next_from_persistence)
+        if msg is None and self.sqlite_handler:
+            writer = getattr(self, "_client_writer", None)
+            row = await asyncio.to_thread(
+                self.sqlite_handler.companion_peek_message, self.companion_hash
+            )
+            if writer is not getattr(self, "_client_writer", None):
+                return  # another client took the slot during the read
+            if row is not None:
+                msg = self._queued_message_from_row(row)
+                frame = self._build_message_frame(msg)
+                if len(frame) > MAX_PAYLOAD_SIZE:
+                    # Undeliverable over frames; drop it as before rather than
+                    # re-serving it forever.
+                    logger.warning(
+                        "Companion %s: dropping message %s (%d bytes exceeds frame size)",
+                        self.companion_hash,
+                        row["id"],
+                        len(frame),
+                    )
+                    await asyncio.to_thread(
+                        self.sqlite_handler.companion_delete_message, self.companion_hash, row["id"]
+                    )
+                    await self._cmd_sync_next_message(data)
+                    return
+                self._pending_delete = (writer, row["id"])
+                self._write_frame(frame)
+                return
         if msg is None:
             self._write_frame(bytes([RESP_CODE_NO_MORE_MESSAGES]))
             return

--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -4268,12 +4268,12 @@ class SQLiteHandler:
             logger.error(f"Failed to push companion message: {e}")
             return False
 
-    def companion_pop_message(self, companion_hash: str) -> Optional[Dict]:
-        """Remove and return the oldest message from the companion's queue."""
+    def companion_peek_message(self, companion_hash: str) -> Optional[Dict]:
+        """Return the oldest queued message, with its ``id``, without removing it."""
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
-                cursor = conn.execute(
+                row = conn.execute(
                     """
                     SELECT id, sender_key, txt_type, timestamp, text, is_channel, channel_idx,
                            path_len, sender_prefix, snr, rssi, channel_data_type,
@@ -4282,8 +4282,7 @@ class SQLiteHandler:
                     ORDER BY id ASC LIMIT 1
                 """,
                     (companion_hash,),
-                )
-                row = cursor.fetchone()
+                ).fetchone()
                 if not row:
                     return None
                 msg = dict(row)
@@ -4292,9 +4291,29 @@ class SQLiteHandler:
                 msg["rssi"] = int(msg.get("rssi") or 0)
                 msg["channel_data_type"] = int(msg.get("channel_data_type") or 0)
                 msg["channel_data_payload"] = bytes(msg.get("channel_data_payload") or b"")
-                conn.execute("DELETE FROM companion_messages WHERE id = ?", (msg["id"],))
-                conn.commit()
-                return {k: v for k, v in msg.items() if k != "id"}
+                return msg
         except Exception as e:
-            logger.error(f"Failed to pop companion message: {e}")
+            logger.error(f"Failed to peek companion message: {e}")
             return None
+
+    def companion_delete_message(self, companion_hash: str, message_id: int) -> bool:
+        """Remove one queued message once the client has demonstrably received it."""
+        try:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM companion_messages WHERE id = ? AND companion_hash = ?",
+                    (message_id, companion_hash),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+        except Exception as e:
+            logger.error(f"Failed to delete companion message: {e}")
+            return False
+
+    def companion_pop_message(self, companion_hash: str) -> Optional[Dict]:
+        """Remove and return the oldest message from the companion's queue."""
+        msg = self.companion_peek_message(companion_hash)
+        if not msg:
+            return None
+        self.companion_delete_message(companion_hash, msg.pop("id"))
+        return msg

--- a/tests/test_companion_bridge_frame_utils.py
+++ b/tests/test_companion_bridge_frame_utils.py
@@ -110,19 +110,21 @@ def test_bridge_load_prefs_ignores_invalid_or_missing_backend():
 
 @pytest.mark.asyncio
 async def test_frame_server_persistence_paths_and_stop():
+    persisted = {
+        "id": 1,
+        "sender_key": b"k",
+        "txt_type": 1,
+        "timestamp": 2,
+        "text": "hello",
+        "is_channel": True,
+        "channel_idx": 3,
+        "path_len": 1,
+    }
     sqlite = SimpleNamespace(
         companion_push_message=MagicMock(),
-        companion_pop_message=MagicMock(
-            return_value={
-                "sender_key": b"k",
-                "txt_type": 1,
-                "timestamp": 2,
-                "text": "hello",
-                "is_channel": True,
-                "channel_idx": 3,
-                "path_len": 1,
-            }
-        ),
+        companion_delete_message=MagicMock(),
+        companion_pop_message=MagicMock(return_value=persisted),
+        companion_peek_message=MagicMock(return_value=persisted),
         companion_save_contacts=MagicMock(),
         companion_save_channels=MagicMock(),
         companion_upsert_contact=MagicMock(),
@@ -206,13 +208,14 @@ async def test_frame_server_no_more_messages_response_when_empty():
 @pytest.mark.asyncio
 async def test_restart_queue_rows_are_delivered_once_from_sqlite():
     sqlite = SimpleNamespace(
-        companion_pop_message=MagicMock(
+        companion_delete_message=MagicMock(),
+        companion_peek_message=MagicMock(
             side_effect=[
-                {"sender_key": b"a", "timestamp": 1, "text": "first"},
-                {"sender_key": b"b", "timestamp": 2, "text": "second"},
+                {"id": 1, "sender_key": b"a", "timestamp": 1, "text": "first"},
+                {"id": 2, "sender_key": b"b", "timestamp": 2, "text": "second"},
                 None,
             ]
-        )
+        ),
     )
     bridge = SimpleNamespace(sync_next_message=lambda: None)
 
@@ -234,7 +237,7 @@ async def test_restart_queue_rows_are_delivered_once_from_sqlite():
         b"second",
         bytes([RESP_CODE_NO_MORE_MESSAGES]),
     ]
-    assert sqlite.companion_pop_message.call_count == 3
+    assert sqlite.companion_peek_message.call_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_companion_sync_receipt.py
+++ b/tests/test_companion_sync_receipt.py
@@ -1,0 +1,112 @@
+"""A synced companion message is removed on the client's next command, not on read.
+
+``SYNC_NEXT_MESSAGE`` used to delete the SQLite row before the frame reached
+the client, so a connection that dropped in between lost the message. The
+row is now deleted when the same client sends its next command; a client that
+disconnects, or is evicted, first is sent the message again.
+"""
+
+from __future__ import annotations
+
+import pytest
+from openhop_core.companion.constants import CMD_SYNC_NEXT_MESSAGE, RESP_CODE_NO_MORE_MESSAGES
+from openhop_core.companion.message_queue import MessageQueue
+
+from repeater.companion.frame_server import CompanionFrameServer
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler
+
+_HASH = "0x01"
+
+
+class _Bridge:
+    def __init__(self):
+        self.message_queue = MessageQueue(max_size=100)
+
+    def sync_next_message(self):
+        return self.message_queue.pop()
+
+
+def _server(handler, writer=None):
+    fs = CompanionFrameServer(_Bridge(), _HASH, port=0, sqlite_handler=handler)
+    fs._app_target_ver = 3
+    fs._client_writer = writer or object()
+    fs.frames = []
+    fs._write_frame = lambda data: fs.frames.append(bytes(data))
+    return fs
+
+
+def _push(handler, text, packet_hash):
+    assert handler.companion_push_message(
+        _HASH,
+        {
+            "sender_key": b"\x11" * 32,
+            "text": text,
+            "timestamp": 1000,
+            "txt_type": 0,
+            "is_channel": False,
+            "channel_idx": 0,
+            "path_len": 0xFF,
+            "packet_hash": packet_hash,
+        },
+        100,
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_stays_queued_until_the_next_command(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "first", "p1")
+    fs = _server(handler)
+
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert fs.frames[-1][0] != RESP_CODE_NO_MORE_MESSAGES
+    assert handler.companion_count_messages(_HASH) == 1
+
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert fs.frames[-1][0] == RESP_CODE_NO_MORE_MESSAGES
+    assert handler.companion_count_messages(_HASH) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_client_that_drops_first_is_sent_the_message_again(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "only", "p1")
+    fs = _server(handler)
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+
+    # Disconnect or eviction: the base replaces the writer before any further
+    # command. The next client's first command is not the old client's receipt.
+    fs._client_writer = object()
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert fs.frames[-1][0] != RESP_CODE_NO_MORE_MESSAGES
+    assert handler.companion_count_messages(_HASH) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_client_evicted_during_the_read_is_not_served(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "only", "p1")
+    fs = _server(handler)
+    original = handler.companion_peek_message
+
+    def swap_then_read(companion_hash):
+        fs._client_writer = object()
+        return original(companion_hash)
+
+    handler.companion_peek_message = swap_then_read
+    await fs._cmd_sync_next_message(b"")
+    assert fs.frames == []
+    assert fs._pending_delete is None
+    assert handler.companion_count_messages(_HASH) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_message_too_large_for_a_frame_is_dropped_not_stuck(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "x" * 170, "p1")
+    _push(handler, "fits", "p2")
+    fs = _server(handler)
+
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert len(fs.frames) == 1 and b"fits" in fs.frames[0]
+    assert handler.companion_count_messages(_HASH) == 1


### PR DESCRIPTION
## The problem

`SYNC_NEXT_MESSAGE` deletes the SQLite row before the frame reaches the client. A connection that drops in between loses the message. Over a direct socket the window is tiny; over the `/ws/companion_frame` proxy plus a phone that backgrounds, it is real.

## The fix

The row is deleted when the same client sends its next command, not when it is read. A client that disconnects, or is evicted by another client, before that is sent the message again on its next sync. A message too large for a frame is dropped as before rather than re-served forever.

- `sqlite_handler`: `companion_peek_message` (the existing pop's read, without the delete) and `companion_delete_message`. `companion_pop_message` is untouched.
- `frame_server`: the pending id is captured on the event loop before the read, so a client that takes the slot during the read is never handed the other client's message; `_handle_cmd` deletes on the next command from the same client.

No schema, config, or API change. Three files, +200 lines, most of it tests.

## What changes for clients

Delivery becomes at-least-once instead of at-most-once: a client that drops right after receiving its last message may see it once more on reconnect. A client that drains to `NO_MORE_MESSAGES` is unaffected, since that final sync is the receipt.

## Validation

- `tests/test_companion_sync_receipt.py`: queued until the next command, re-sent after a drop, not served to a client that took the slot mid-read, oversize frame dropped rather than stuck.
- Two existing tests that mocked `companion_pop_message` on the sync path now mock peek/delete.
- Full suite: 1938 passed. `pre-commit run` clean.
