### PR TITLE
feat(api): read companion message history by cursor

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -624,9 +624,9 @@ storage:
   retention:
     # Clean up SQLite records older than this many days
     sqlite_cleanup_days: 31
-    # Companion event journal / soft-consumed message history retention.
-    # Independent of sqlite_cleanup_days so packet RF history and companion
-    # sync history can be sized separately. Defaults to 31 when omitted.
+    # Delivered companion message history retention. Messages a companion
+    # client has synced stay in SQLite this many days; undelivered messages
+    # are a queue and are never pruned. Defaults to 31 when omitted.
     companion_events_days: 31
 
     # RRD archives are managed automatically:

--- a/repeater/companion/frame_server.py
+++ b/repeater/companion/frame_server.py
@@ -28,6 +28,11 @@ class CompanionFrameServer(_BaseFrameServer):
     zero changes.
     """
 
+    # (client writer, SQLite message id) handed out by SYNC_NEXT_MESSAGE and
+    # not yet acknowledged. The client's next command is the receipt; a
+    # client that leaves first keeps the row queued.
+    _pending_delivery: Optional[tuple] = None
+
     def __init__(
         self,
         bridge,
@@ -156,12 +161,18 @@ class CompanionFrameServer(_BaseFrameServer):
         self.bridge.message_queue.remove(queue_entry)
 
     def _sync_next_from_persistence(self) -> Optional[QueuedMessage]:
-        """Retrieve next message from SQLite when bridge queue is empty."""
+        """Retrieve the next undelivered SQLite message when the bridge queue is empty.
+
+        The row is not consumed here: it is marked delivered when the client's
+        next command arrives (:meth:`_handle_cmd`), so a client that drops
+        between the read and the receipt sees the message again.
+        """
         if not self.sqlite_handler:
             return None
-        msg_dict = self.sqlite_handler.companion_pop_message(self.companion_hash)
+        msg_dict = self.sqlite_handler.companion_next_undelivered_message(self.companion_hash)
         if not msg_dict:
             return None
+        self._pending_delivery = (getattr(self, "_client_writer", None), msg_dict["id"])
         sender_prefix = msg_dict.get("sender_prefix", b"")
         if isinstance(sender_prefix, str):
             sender_prefix = bytes.fromhex(sender_prefix) if sender_prefix else b""
@@ -183,6 +194,27 @@ class CompanionFrameServer(_BaseFrameServer):
     # -----------------------------------------------------------------
     # Non-blocking command overrides (keep event loop responsive)
     # -----------------------------------------------------------------
+
+    def _ack_pending_delivery(self) -> None:
+        """Mark the outstanding delivery received, if the same client is still here."""
+        pending, self._pending_delivery = self._pending_delivery, None
+        if pending is None:
+            return
+        writer, message_id = pending
+        if writer is getattr(self, "_client_writer", None):
+            self.sqlite_handler.companion_mark_delivered(self.companion_hash, message_id)
+
+    async def _handle_cmd(self, payload: bytes) -> None:
+        """Any further command from the client is the receipt for the last message."""
+        if self._pending_delivery is not None:
+            await asyncio.to_thread(self._ack_pending_delivery)
+        await super()._handle_cmd(payload)
+
+    async def _cleanup_client(self, writer, write_queue, writer_task, disconnect_reason) -> None:
+        """A client that leaves without acknowledging keeps its last message queued."""
+        if self._pending_delivery is not None and self._pending_delivery[0] is writer:
+            self._pending_delivery = None
+        await super()._cleanup_client(writer, write_queue, writer_task, disconnect_reason)
 
     async def _cmd_sync_next_message(self, data: bytes) -> None:
         """Sync next message; run persistence read in thread so SQLite does not block."""

--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -4302,6 +4302,34 @@ class SQLiteHandler:
             logger.error(f"Failed to push companion message: {e}")
             return False
 
+    def companion_load_history(
+        self, companion_hash: str, since_id: int = 0, limit: int = 100
+    ) -> Optional[List[Dict]]:
+        """Received messages after ``since_id`` (exclusive), oldest first, with ids.
+
+        Delivered and undelivered rows alike: this is the mailbox a client
+        reads by cursor, not the frame queue. Returns None on failure so a
+        caller never mistakes an error for an empty page.
+        """
+        try:
+            with self._connect() as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.execute(
+                    """
+                    SELECT id, sender_key, txt_type, timestamp, text, is_channel, channel_idx,
+                           path_len, sender_prefix, snr, rssi, channel_data_type,
+                           channel_data_payload, delivered_at, created_at
+                    FROM companion_messages
+                    WHERE companion_hash = ? AND id > ?
+                    ORDER BY id ASC LIMIT ?
+                """,
+                    (companion_hash, since_id, limit),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Failed to load companion history for {companion_hash}: {e}")
+            return None
+
     def companion_next_undelivered_message(self, companion_hash: str) -> Optional[Dict]:
         """Return the oldest undelivered message (with its ``id``) without consuming it.
 

--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -709,6 +709,27 @@ class SQLiteHandler:
                     )
                     logger.info(f"Migration '{migration_name}' applied successfully")
 
+                # companion_messages.delivered_at: NULL marks the undelivered
+                # queue; a delivered row is history until retention prunes it.
+                # Guarded on the column as well as the marker, so a table
+                # rebuilt by an earlier migration gets it back.
+                migration_name = "add_delivered_at_to_companion_messages"
+                cursor = conn.execute("PRAGMA table_info(companion_messages)")
+                columns = [column[1] for column in cursor.fetchall()]
+                if "delivered_at" not in columns:
+                    conn.execute("ALTER TABLE companion_messages ADD COLUMN delivered_at REAL")
+                    logger.info("Added delivered_at column to companion_messages table")
+                existing = conn.execute(
+                    "SELECT migration_name FROM migrations WHERE migration_name = ?",
+                    (migration_name,),
+                ).fetchone()
+                if not existing:
+                    conn.execute(
+                        "INSERT INTO migrations (migration_name, applied_at) VALUES (?, ?)",
+                        (migration_name, time.time()),
+                    )
+                    logger.info(f"Migration '{migration_name}' applied successfully")
+
                 # Migration 13: Add upstream hash fields to packets for
                 # neighbour-link history lookups and indexing.
                 migration_name = "add_upstream_hash_to_packets"
@@ -2857,14 +2878,14 @@ class SQLiteHandler:
     def cleanup_old_data(self, days: int = 7, companion_events_days: Optional[int] = None):
         """Prune retention-bounded tables.
 
-        ``companion_events_days`` is forwarded from engine.py
-        (``storage.retention.companion_events_days``, default 31). Accepted here
-        so the periodic cleanup call cannot TypeError and silently skip all
-        SQLite pruning. Companion journal/history pruning is layered on by the
-        companion-api storage work once those tables exist.
+        ``companion_events_days`` (``storage.retention.companion_events_days``,
+        default 31) bounds delivered companion message history. Undelivered
+        messages are a queue, not history, and are never pruned here.
         """
         try:
             cutoff = time.time() - (days * 24 * 3600)
+            history_days = companion_events_days if companion_events_days is not None else 31
+            history_cutoff = time.time() - (history_days * 24 * 3600)
 
             with self._connect() as conn:
                 result = conn.execute("DELETE FROM packets WHERE timestamp < ?", (cutoff,))
@@ -2887,6 +2908,13 @@ class SQLiteHandler:
                 result = conn.execute("DELETE FROM crc_errors WHERE timestamp < ?", (cutoff,))
                 crc_deleted = result.rowcount
 
+                result = conn.execute(
+                    "DELETE FROM companion_messages "
+                    "WHERE delivered_at IS NOT NULL AND delivered_at < ?",
+                    (history_cutoff,),
+                )
+                companion_deleted = result.rowcount
+
                 conn.commit()
 
                 if (
@@ -2894,9 +2922,10 @@ class SQLiteHandler:
                     or adverts_deleted > 0
                     or noise_deleted > 0
                     or crc_deleted > 0
+                    or companion_deleted > 0
                 ):
                     logger.info(
-                        f"Cleaned up {packets_deleted} old packets, {adverts_deleted} old adverts, {noise_deleted} old noise measurements, {crc_deleted} old CRC error records"
+                        f"Cleaned up {packets_deleted} old packets, {adverts_deleted} old adverts, {noise_deleted} old noise measurements, {crc_deleted} old CRC error records, {companion_deleted} delivered companion messages"
                     )
 
         except Exception as e:
@@ -4114,11 +4143,12 @@ class SQLiteHandler:
             return False
 
     def companion_count_messages(self, companion_hash: str) -> int:
-        """Return the number of persisted queued messages for a companion."""
+        """Return the number of undelivered queued messages for a companion."""
         try:
             with self._connect() as conn:
                 cursor = conn.execute(
-                    "SELECT COUNT(*) FROM companion_messages WHERE companion_hash = ?",
+                    "SELECT COUNT(*) FROM companion_messages "
+                    "WHERE companion_hash = ? AND delivered_at IS NULL",
                     (companion_hash,),
                 )
                 row = cursor.fetchone()
@@ -4130,7 +4160,7 @@ class SQLiteHandler:
     def companion_load_messages(
         self, companion_hash: str, limit: int = 100
     ) -> Optional[List[Dict]]:
-        """Load queued messages for a companion (oldest first for queue order).
+        """Load undelivered queued messages for a companion (oldest first).
 
         Returns [] when the companion has no persisted messages, or None when
         the load failed — callers must not treat a failed load as "no data".
@@ -4143,7 +4173,8 @@ class SQLiteHandler:
                     SELECT sender_key, txt_type, timestamp, text, is_channel, channel_idx,
                            path_len, sender_prefix, snr, rssi, channel_data_type,
                            channel_data_payload
-                    FROM companion_messages WHERE companion_hash = ?
+                    FROM companion_messages
+                    WHERE companion_hash = ? AND delivered_at IS NULL
                     ORDER BY id ASC LIMIT ?
                 """,
                     (companion_hash, limit),
@@ -4224,7 +4255,8 @@ class SQLiteHandler:
                 if max_messages is not None:
                     last_id = cursor.lastrowid
                     count = conn.execute(
-                        "SELECT COUNT(*) FROM companion_messages WHERE companion_hash = ?",
+                        "SELECT COUNT(*) FROM companion_messages "
+                        "WHERE companion_hash = ? AND delivered_at IS NULL",
                         (companion_hash,),
                     ).fetchone()[0]
                     excess = count - max_messages
@@ -4238,6 +4270,7 @@ class SQLiteHandler:
                             """
                             SELECT COUNT(*) FROM companion_messages
                             WHERE companion_hash = ? AND is_channel = 1 AND id != ?
+                              AND delivered_at IS NULL
                             """,
                             (companion_hash, last_id),
                         ).fetchone()[0]
@@ -4256,6 +4289,7 @@ class SQLiteHandler:
                             WHERE id IN (
                                 SELECT id FROM companion_messages
                                 WHERE companion_hash = ? AND is_channel = 1 AND id != ?
+                                  AND delivered_at IS NULL
                                 ORDER BY id ASC LIMIT ?
                             )
                             """,
@@ -4268,8 +4302,13 @@ class SQLiteHandler:
             logger.error(f"Failed to push companion message: {e}")
             return False
 
-    def companion_pop_message(self, companion_hash: str) -> Optional[Dict]:
-        """Remove and return the oldest message from the companion's queue."""
+    def companion_next_undelivered_message(self, companion_hash: str) -> Optional[Dict]:
+        """Return the oldest undelivered message (with its ``id``) without consuming it.
+
+        The caller marks it delivered with :meth:`companion_mark_delivered`
+        once the client has demonstrably received it; until then a dropped
+        connection simply sees the same message again.
+        """
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
@@ -4278,7 +4317,8 @@ class SQLiteHandler:
                     SELECT id, sender_key, txt_type, timestamp, text, is_channel, channel_idx,
                            path_len, sender_prefix, snr, rssi, channel_data_type,
                            channel_data_payload
-                    FROM companion_messages WHERE companion_hash = ?
+                    FROM companion_messages
+                    WHERE companion_hash = ? AND delivered_at IS NULL
                     ORDER BY id ASC LIMIT 1
                 """,
                     (companion_hash,),
@@ -4292,9 +4332,30 @@ class SQLiteHandler:
                 msg["rssi"] = int(msg.get("rssi") or 0)
                 msg["channel_data_type"] = int(msg.get("channel_data_type") or 0)
                 msg["channel_data_payload"] = bytes(msg.get("channel_data_payload") or b"")
-                conn.execute("DELETE FROM companion_messages WHERE id = ?", (msg["id"],))
-                conn.commit()
-                return {k: v for k, v in msg.items() if k != "id"}
+                return msg
         except Exception as e:
-            logger.error(f"Failed to pop companion message: {e}")
+            logger.error(f"Failed to read next companion message: {e}")
             return None
+
+    def companion_mark_delivered(self, companion_hash: str, message_id: int) -> bool:
+        """Mark one queued message delivered; it stays as history until pruned."""
+        try:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    "UPDATE companion_messages SET delivered_at = ? "
+                    "WHERE id = ? AND companion_hash = ? AND delivered_at IS NULL",
+                    (time.time(), message_id, companion_hash),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+        except Exception as e:
+            logger.error(f"Failed to mark companion message delivered: {e}")
+            return False
+
+    def companion_pop_message(self, companion_hash: str) -> Optional[Dict]:
+        """Return the oldest undelivered message and mark it delivered at once."""
+        msg = self.companion_next_undelivered_message(companion_hash)
+        if not msg:
+            return None
+        self.companion_mark_delivered(companion_hash, msg["id"])
+        return {k: v for k, v in msg.items() if k != "id"}

--- a/repeater/web/companion_endpoints.py
+++ b/repeater/web/companion_endpoints.py
@@ -363,6 +363,62 @@ class CompanionAPIEndpoints:
             }
         )
 
+    def _bridge_hash_str(self, bridge) -> str:
+        """The storage key (``0x??``) of a resolved bridge."""
+        bridges = getattr(self.daemon_instance, "companion_bridges", {}) or {}
+        for hash_byte, candidate in bridges.items():
+            if candidate is bridge:
+                return f"0x{hash_byte:02x}"
+        raise cherrypy.HTTPError(404, "Companion not found")
+
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    @require_auth
+    def messages(self, **kwargs):
+        """GET /api/companion/messages?since=<id>&limit=<n> — received message history.
+
+        Oldest first, ``id`` ascending; pass the last ``id`` seen as ``since``
+        to read only what is new. Rows a frame client has synced are included
+        (``delivered`` true), so every client reads the same mailbox.
+        """
+        bridge = self._get_bridge(**self._resolve_bridge_params(kwargs))
+        sqlite_handler = self._get_sqlite_handler()
+        try:
+            since = int(kwargs.get("since", 0))
+            limit = int(kwargs.get("limit", 100))
+        except (TypeError, ValueError):
+            raise cherrypy.HTTPError(400, "since and limit must be integers")
+        if since < 0 or limit < 1:
+            raise cherrypy.HTTPError(400, "since must be >= 0 and limit >= 1")
+        limit = min(limit, 500)
+        rows = sqlite_handler.companion_load_history(self._bridge_hash_str(bridge), since, limit)
+        if rows is None:
+            raise cherrypy.HTTPError(503, "Message history unavailable")
+        items = []
+        for row in rows:
+            sender_key = row.get("sender_key") or b""
+            payload = row.get("channel_data_payload") or b""
+            items.append(
+                {
+                    "id": row["id"],
+                    "sender_key": sender_key.hex() if isinstance(sender_key, bytes) else sender_key,
+                    "txt_type": row.get("txt_type", 0),
+                    "timestamp": row.get("timestamp", 0),
+                    "text": row.get("text", ""),
+                    "is_channel": bool(row.get("is_channel")),
+                    "channel_idx": row.get("channel_idx", 0),
+                    "path_len": row.get("path_len", 0),
+                    "sender_prefix": row.get("sender_prefix") or "",
+                    "snr": float(row.get("snr") or 0.0),
+                    "rssi": int(row.get("rssi") or 0),
+                    "channel_data_type": int(row.get("channel_data_type") or 0),
+                    "channel_data_payload": payload.hex() if isinstance(payload, bytes) else "",
+                    "delivered": row.get("delivered_at") is not None,
+                    "received_at": row.get("created_at", 0),
+                }
+            )
+        return self._success(items)
+
     @cherrypy.expose
     @cherrypy.tools.json_out()
     @require_auth

--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -4247,6 +4247,42 @@ paths:
               schema:
                 type: object
 
+  /companion/messages:
+    get:
+      tags: [System]
+      summary: Received companion message history, oldest first
+      description: |
+        Messages received by the companion, delivered or not, with ascending ids.
+        Pass the last id seen as `since` to read only what is new.
+      parameters:
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: companion_name
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Messages
+          content:
+            application/json:
+              schema:
+                type: object
+
   /companion/import_repeater_contacts:
     post:
       tags: [System]

--- a/tests/test_companion_bridge_frame_utils.py
+++ b/tests/test_companion_bridge_frame_utils.py
@@ -112,8 +112,10 @@ def test_bridge_load_prefs_ignores_invalid_or_missing_backend():
 async def test_frame_server_persistence_paths_and_stop():
     sqlite = SimpleNamespace(
         companion_push_message=MagicMock(),
-        companion_pop_message=MagicMock(
+        companion_mark_delivered=MagicMock(),
+        companion_next_undelivered_message=MagicMock(
             return_value={
+                "id": 7,
                 "sender_key": b"k",
                 "txt_type": 1,
                 "timestamp": 2,
@@ -206,13 +208,14 @@ async def test_frame_server_no_more_messages_response_when_empty():
 @pytest.mark.asyncio
 async def test_restart_queue_rows_are_delivered_once_from_sqlite():
     sqlite = SimpleNamespace(
-        companion_pop_message=MagicMock(
+        companion_mark_delivered=MagicMock(),
+        companion_next_undelivered_message=MagicMock(
             side_effect=[
-                {"sender_key": b"a", "timestamp": 1, "text": "first"},
-                {"sender_key": b"b", "timestamp": 2, "text": "second"},
+                {"id": 1, "sender_key": b"a", "timestamp": 1, "text": "first"},
+                {"id": 2, "sender_key": b"b", "timestamp": 2, "text": "second"},
                 None,
             ]
-        )
+        ),
     )
     bridge = SimpleNamespace(sync_next_message=lambda: None)
 
@@ -234,7 +237,7 @@ async def test_restart_queue_rows_are_delivered_once_from_sqlite():
         b"second",
         bytes([RESP_CODE_NO_MORE_MESSAGES]),
     ]
-    assert sqlite.companion_pop_message.call_count == 3
+    assert sqlite.companion_next_undelivered_message.call_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_companion_durable_sync.py
+++ b/tests/test_companion_durable_sync.py
@@ -1,0 +1,156 @@
+"""A synced companion message is not lost when the client drops.
+
+``SYNC_NEXT_MESSAGE`` used to delete the SQLite row before the frame reached
+the client.  Now the row is marked delivered only when the client's next
+command arrives; a client that disconnects (or is evicted) first sees the
+same message again.  Delivered rows stay as history until retention prunes
+them, and the offline-queue cap counts undelivered rows only.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from openhop_core.companion.constants import CMD_SYNC_NEXT_MESSAGE, RESP_CODE_NO_MORE_MESSAGES
+from openhop_core.companion.message_queue import MessageQueue
+
+from repeater.companion.frame_server import CompanionFrameServer
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler
+
+_HASH = "0x01"
+
+
+class _Bridge:
+    def __init__(self):
+        self.message_queue = MessageQueue(max_size=100)
+
+    def sync_next_message(self):
+        return self.message_queue.pop()
+
+
+def _server(handler, writer=None):
+    fs = CompanionFrameServer.__new__(CompanionFrameServer)
+    fs.sqlite_handler = handler
+    fs.companion_hash = _HASH
+    fs.bridge = _Bridge()
+    fs._app_target_ver = 3
+    fs._client_writer = writer or object()
+    fs.port = 5000
+    fs._pending_delivery = None
+    fs._cmd_handlers = {CMD_SYNC_NEXT_MESSAGE: fs._cmd_sync_next_message}
+    fs.frames = []
+    fs._write_frame = lambda data: fs.frames.append(bytes(data))
+    return fs
+
+
+def _push(handler, text, packet_hash, is_channel=False):
+    assert handler.companion_push_message(
+        _HASH,
+        {
+            "sender_key": b"\x11" * 32,
+            "text": text,
+            "timestamp": 1000,
+            "txt_type": 0,
+            "is_channel": is_channel,
+            "channel_idx": 0,
+            "path_len": 0xFF,
+            "packet_hash": packet_hash,
+        },
+        100,
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_stays_queued_until_the_next_command(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "first", "p1")
+    fs = _server(handler)
+
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert len(fs.frames) == 1
+    assert fs.frames[0][0] != RESP_CODE_NO_MORE_MESSAGES
+    # Not yet acknowledged: still counted as undelivered.
+    assert handler.companion_count_messages(_HASH) == 1
+
+    # The next command is the acknowledgement.
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert handler.companion_count_messages(_HASH) == 0
+    assert fs.frames[1][0] == RESP_CODE_NO_MORE_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_dropped_client_sees_the_message_again(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "only", "p1")
+    writer = object()
+    fs = _server(handler, writer)
+
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert fs._pending_delivery == (writer, 1)
+
+    # Disconnect before any further command: the delivery is abandoned, not
+    # acknowledged, and the row is still queued for the next session.
+    fs._write_queue = None
+    fs._writer_task = None
+    fs._client_reader = None
+    await fs._cleanup_client(writer, MagicMock(), MagicMock(done=lambda: True), "empty_read")
+    assert fs._pending_delivery is None
+    assert handler.companion_count_messages(_HASH) == 1
+
+    fs._client_writer = object()
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert fs.frames[-1][0] != RESP_CODE_NO_MORE_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_an_evicting_client_cannot_acknowledge_for_the_old_one(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "only", "p1")
+    old_writer = object()
+    fs = _server(handler, old_writer)
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+
+    # A new client takes the slot before the old one acknowledges.
+    fs._client_writer = object()
+    fs._ack_pending_delivery()
+    assert handler.companion_count_messages(_HASH) == 1
+
+
+def test_delivered_rows_are_history_until_retention_prunes_them(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "old", "p1")
+    _push(handler, "new", "p2")
+    _push(handler, "queued", "p3")
+    old = handler.companion_pop_message(_HASH)
+    new = handler.companion_pop_message(_HASH)
+    assert (old["text"], new["text"]) == ("old", "new")
+    assert handler.companion_count_messages(_HASH) == 1
+
+    with handler._connect() as conn:
+        conn.execute(
+            "UPDATE companion_messages SET delivered_at = ? WHERE text = 'old'",
+            (time.time() - 40 * 86400,),
+        )
+        conn.commit()
+    handler.cleanup_old_data(days=7, companion_events_days=31)
+    with handler._connect() as conn:
+        texts = [r[0] for r in conn.execute("SELECT text FROM companion_messages ORDER BY id")]
+    assert texts == ["new", "queued"]
+
+
+def test_offline_queue_cap_counts_undelivered_only(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    for i in range(3):
+        _push(handler, f"c{i}", f"p{i}", is_channel=True)
+    assert handler.companion_pop_message(_HASH)["text"] == "c0"
+    assert handler.companion_pop_message(_HASH)["text"] == "c1"
+    # Two delivered rows remain as history; only one row is queued, so a cap
+    # of 2 admits the next message without evicting anything.
+    assert handler.companion_push_message(
+        _HASH,
+        {"text": "c3", "timestamp": 1, "packet_hash": "p3", "is_channel": True},
+        2,
+    )
+    assert [m["text"] for m in handler.companion_load_messages(_HASH)] == ["c2", "c3"]

--- a/tests/test_companion_mailbox_flow.py
+++ b/tests/test_companion_mailbox_flow.py
@@ -1,0 +1,104 @@
+"""The mailbox loop a client runs against the API.
+
+A received message is persisted; the bridge's ``message_received`` event is
+the wake signal an SSE client sees; the client then reads by cursor from
+``/api/companion/messages``; a frame client that syncs the same row marks it
+delivered on its next command; the cursor read reflects that, and a further
+read from the last id returns nothing new. Frame and API clients read one
+mailbox.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from openhop_core.companion import CompanionBridge
+from openhop_core.companion.constants import CMD_SYNC_NEXT_MESSAGE, RESP_CODE_NO_MORE_MESSAGES
+from openhop_core.companion.models import MessageEvent
+from openhop_core.protocol import LocalIdentity, Packet
+
+from repeater.companion.frame_server import CompanionFrameServer
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler
+from repeater.web.companion_endpoints import CompanionAPIEndpoints
+
+_HASH = "0x01"
+
+
+class _Injector:
+    async def __call__(self, pkt: Packet, **kwargs) -> bool:
+        return True
+
+
+def _endpoints(bridge, handler):
+    ep = CompanionAPIEndpoints.__new__(CompanionAPIEndpoints)
+    ep._sse_callbacks = []
+    ep._get_bridge = lambda **kw: bridge
+    ep.daemon_instance = SimpleNamespace(
+        companion_bridges={1: bridge},
+        repeater_handler=SimpleNamespace(storage=SimpleNamespace(sqlite_handler=handler)),
+    )
+    ep.broadcasts = []
+    ep._broadcast_sse = ep.broadcasts.append
+    return ep
+
+
+def _frame_client(handler, bridge):
+    fs = CompanionFrameServer.__new__(CompanionFrameServer)
+    fs.sqlite_handler = handler
+    fs.companion_hash = _HASH
+    fs.bridge = bridge
+    fs._app_target_ver = 3
+    fs._client_writer = object()
+    fs.port = 5000
+    fs._pending_delivery = None
+    fs._cmd_handlers = {CMD_SYNC_NEXT_MESSAGE: fs._cmd_sync_next_message}
+    fs.frames = []
+    fs._write_frame = lambda data: fs.frames.append(bytes(data))
+    return fs
+
+
+def _messages(ep, **kwargs):
+    return CompanionAPIEndpoints.messages.__wrapped__(ep, **kwargs)["data"]
+
+
+@pytest.mark.asyncio
+async def test_api_and_frame_clients_read_one_mailbox(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    bridge = CompanionBridge(LocalIdentity(), _Injector())
+    ep = _endpoints(bridge, handler)
+    ep._ensure_callbacks()
+
+    # A message arrives: persisted for sync, and the event stream is woken.
+    assert handler.companion_push_message(
+        _HASH,
+        {"sender_key": b"\x11" * 32, "text": "hello", "timestamp": 1, "packet_hash": "p1"},
+        100,
+    )
+    await bridge._fire_callbacks(
+        "message_event",
+        MessageEvent(sender_key=b"\x11" * 32, text="hello", timestamp=1, txt_type=0),
+    )
+    assert [b["event"] for b in ep.broadcasts] == ["message_received"]
+
+    # The API client reads by cursor and sees the row, not yet delivered.
+    page = _messages(ep, since=0)
+    assert [(m["id"], m["text"], m["delivered"]) for m in page] == [(1, "hello", False)]
+    cursor = page[-1]["id"]
+
+    # A frame client syncs the same row; its next command is the receipt.
+    fs = _frame_client(handler, bridge)
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert _messages(ep, since=0)[0]["delivered"] is False
+    await fs._handle_cmd(bytes([CMD_SYNC_NEXT_MESSAGE]))
+    assert fs.frames[-1][0] == RESP_CODE_NO_MORE_MESSAGES
+    assert _messages(ep, since=0)[0]["delivered"] is True
+
+    # Nothing new after the cursor; the next message appears after it.
+    assert _messages(ep, since=cursor) == []
+    assert handler.companion_push_message(
+        _HASH,
+        {"sender_key": b"\x11" * 32, "text": "again", "timestamp": 2, "packet_hash": "p2"},
+        100,
+    )
+    assert [m["text"] for m in _messages(ep, since=cursor)] == ["again"]

--- a/tests/test_companion_message_history.py
+++ b/tests/test_companion_message_history.py
@@ -1,0 +1,96 @@
+"""GET /api/companion/messages reads the mailbox by cursor.
+
+Every client — a frame client that syncs, a REST client that polls — sees the
+same received messages with the same ascending ids. ``since`` is the last id a
+client has applied; ``delivered`` says whether a frame client already synced
+the row.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import cherrypy
+import pytest
+
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler
+from repeater.web.companion_endpoints import CompanionAPIEndpoints
+
+_HASH = "0x01"
+
+
+def _push(handler, text, packet_hash, is_channel=False):
+    assert handler.companion_push_message(
+        _HASH,
+        {
+            "sender_key": b"\x11" * 32,
+            "text": text,
+            "timestamp": 1000,
+            "txt_type": 0,
+            "is_channel": is_channel,
+            "channel_idx": 2,
+            "path_len": 0xFF,
+            "packet_hash": packet_hash,
+            "sender_prefix": b"\xaa\xbb\xcc\xdd",
+        },
+        100,
+    )
+
+
+def _endpoints(handler):
+    bridge = object()
+    ep = CompanionAPIEndpoints.__new__(CompanionAPIEndpoints)
+    ep.daemon_instance = SimpleNamespace(
+        companion_bridges={1: bridge},
+        repeater_handler=SimpleNamespace(storage=SimpleNamespace(sqlite_handler=handler)),
+    )
+    ep._get_bridge = lambda **kw: bridge
+    return ep
+
+
+def _messages(ep, **kwargs):
+    """Call past the @require_auth wrapper (no auth context in tests)."""
+    return CompanionAPIEndpoints.messages.__wrapped__(ep, **kwargs)
+
+
+def test_history_is_read_by_cursor_and_marks_delivery(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "one", "p1")
+    _push(handler, "two", "p2", is_channel=True)
+    _push(handler, "three", "p3")
+    assert handler.companion_pop_message(_HASH)["text"] == "one"
+    ep = _endpoints(handler)
+
+    page = _messages(ep)
+    assert page["success"] is True
+    items = page["data"]
+    assert [m["text"] for m in items] == ["one", "two", "three"]
+    assert [m["id"] for m in items] == [1, 2, 3]
+    assert [m["delivered"] for m in items] == [True, False, False]
+    assert items[0]["sender_key"] == "11" * 32
+    assert items[0]["sender_prefix"] == "aabbccdd"
+    assert items[1]["is_channel"] is True and items[1]["channel_idx"] == 2
+
+    assert [m["text"] for m in _messages(ep, since=2)["data"]] == ["three"]
+    assert [m["text"] for m in _messages(ep, since=3)["data"]] == []
+    assert len(_messages(ep, limit=1)["data"]) == 1
+
+
+def test_bad_cursor_values_are_rejected(tmp_path):
+    ep = _endpoints(SQLiteHandler(tmp_path))
+    with pytest.raises(cherrypy.HTTPError):
+        _messages(ep, since="abc")
+    with pytest.raises(cherrypy.HTTPError):
+        _messages(ep, since=-1)
+    with pytest.raises(cherrypy.HTTPError):
+        _messages(ep, limit=0)
+
+
+def test_history_scopes_to_the_resolved_companion(tmp_path):
+    handler = SQLiteHandler(tmp_path)
+    _push(handler, "mine", "p1")
+    assert handler.companion_push_message(
+        "0x02", {"text": "theirs", "timestamp": 1, "packet_hash": "p9"}, 100
+    )
+    ep = _endpoints(handler)
+    assert [m["text"] for m in _messages(ep)["data"]] == ["mine"]

--- a/tests/test_companion_settings.py
+++ b/tests/test_companion_settings.py
@@ -455,7 +455,8 @@ class TestSenderPrefixPersistence:
         fs = CompanionFrameServer.__new__(CompanionFrameServer)
         fs.sqlite_handler = MagicMock()
         fs.companion_hash = "0x01"
-        fs.sqlite_handler.companion_pop_message.return_value = {
+        fs.sqlite_handler.companion_next_undelivered_message.return_value = {
+            "id": 1,
             "sender_key": b"\x01" * 32,
             "txt_type": 2,
             "timestamp": 42,


### PR DESCRIPTION
## Summary

`GET /api/companion/messages?since=<id>&limit=<n>` returns received companion messages oldest first with their ascending ids, delivered or not. A client passes the last id it applied as `since` to read only what is new. `delivered` says whether a frame client already synced the row, so a frame client and an API client read the same mailbox.

Stacks on #470 (it reads the `delivered_at` history that change keeps); the first commit here is #470's. Only the second commit is this PR.

## What changed

- `sqlite_handler.companion_load_history(companion_hash, since_id, limit)`: one read over `companion_messages`, `id > since`, ascending, bounded.
- `CompanionAPIEndpoints.messages`: resolves the companion the same way every other companion route does, validates `since` and `limit` (max 500), returns the `{success, data}` envelope.
- OpenAPI entry for `/companion/messages`.

Three files plus a test, +150 lines.

## Validation

- `tests/test_companion_message_history.py`: cursor paging, delivered flag, hex fields, bad values rejected, scoped to the resolved companion.
- `pre-commit run` clean on changed files, including the OpenAPI contract check.

Live delivery already exists as the `message_received` / `channel_message_received` SSE events on `/api/companion/events`; a client uses those as the wake signal and this endpoint as the source of truth.
